### PR TITLE
refactor(mat!): convert mat! into a syntax extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ name = "linalg"
 version = "0.0.0"
 authors = ["Jorge Aparicio <japaric@linux.com>"]
 
+[dependencies.linalg_macros]
+path = "macros"
+
 [dependencies.num]
 git = "https://github.com/rust-lang/num"
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+
+name = "linalg_macros"
+version = "0.0.0"
+authors = ["Jorge Aparicio <japaric@linux.com>"]
+
+[lib]
+name = "linalg_macros"
+plugin = true

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,264 @@
+#![deny(warnings)]
+#![feature(if_let, macro_rules, plugin_registrar, slicing_syntax)]
+
+extern crate rustc;
+extern crate syntax;
+
+use rustc::plugin::registry::Registry;
+use std::ptr;
+use syntax::ast::{ExprBox, Inherited, LitInt, Plus, TTTok, TokenTree, UnsuffixedIntLit};
+use syntax::codemap::Span;
+use syntax::ext::base::{DummyResult, ExtCtxt, MacExpr, MacResult, NormalTT};
+use syntax::ext::build::AstBuilder;
+use syntax::parse::token::{mod, COMMA, SEMI};
+
+#[macro_export]
+/// Creates an owned matrix from its arguments
+///
+/// - Each argument is an element of the matrix
+/// - Semicolons `;` are used to separate rows
+/// - Trailing semicolons are allowed
+/// - Commas `,` are used to separate columns
+/// - Trailing commas are *not* allowed
+/// - If the matrix contains a single row, the macro will return a `Row`
+/// - If the matrix contains a single column, the macro will return a `Col`
+/// - Otherwise, the macro will return `Mat`
+///
+/// # Expansion
+///
+/// There are three possible expansions:
+///
+/// - Row vector
+///
+/// ``` ignore
+/// mat![0, 1, 2]
+/// ```
+///
+/// expands into:
+///
+/// ``` ignore
+/// Row::new(vec![0, 1, 2])
+/// ```
+///
+/// - Column vector
+///
+/// ``` ignore
+/// // NB Newlines are *not* required
+/// mat![
+///     0;
+///     1;
+///     2;  // This semicolon can be removed if desired
+/// ]
+/// ```
+///
+/// expands into:
+///
+/// ``` ignore
+/// Col::new(vec![0, 1, 2])
+/// ```
+///
+/// - Matrix
+///
+/// ``` ignore
+/// mat![
+///     0, 1, 2;
+///     3, 4, 5;
+/// ]
+/// ```
+///
+/// expands into:
+///
+/// ``` ignore
+/// Mat::new(vec![0, 3, 1, 4, 3, 5], 2)
+/// ```
+///
+/// Note that the order of the arguments have changed because matrices are stored in column-major
+/// order
+macro_rules! mat {
+    ($($($elem:expr),+);+;) => { /* syntax extension */ }
+}
+
+#[plugin_registrar]
+#[doc(hidden)]
+pub fn plugin_registrar(r: &mut Registry) {
+    r.register_syntax_extension(token::intern("mat"), NormalTT(box expand_mat, None));
+}
+
+fn expand_mat<'cx>(
+    cx: &'cx mut ExtCtxt,
+    sp: Span,
+    tts: &[TokenTree],
+) -> Box<MacResult + 'cx> {
+    fn at_semicolons(tt: &TokenTree) -> bool {
+        if let TTTok(_, SEMI) = *tt {
+            true
+        } else {
+            false
+        }
+    }
+
+    fn at_commas(tt: &TokenTree) -> bool {
+        if let TTTok(_, COMMA) = *tt {
+            true
+        } else {
+            false
+        }
+    }
+
+    let rows = {
+        let mut rows = tts.split(at_semicolons).collect::<Vec<_>>();
+        // look for trailing semicolon
+        if rows.last().map(|tts| tts.is_empty()) == Some(true) {
+            rows.pop();
+        }
+        rows
+    };
+
+    let nrows = rows.len();
+
+    let matrix = {
+        let mut matrix = Vec::with_capacity(nrows);
+        for (r, row) in rows.into_iter().enumerate() {
+            let elems = row.split(at_commas).collect::<Vec<_>>();
+            // look for trailing commas
+            if elems.last().map(|tts| tts.is_empty()) == Some(true) {
+                let err_msg = format!("row {}: trailing comma not allowed", r);
+                cx.span_err(sp, err_msg[]);
+                return DummyResult::expr(sp);
+            }
+            matrix.push(elems);
+        }
+        matrix
+    };
+
+    let ncols = {
+        let mut cols_per_row = matrix.iter().map(|row| row.len());
+
+        let ncols = match cols_per_row.next() {
+            Some(ncols) => ncols,
+            None => {
+                cx.span_err(sp, "Empty matrix");
+                return DummyResult::expr(sp);
+            },
+        };
+
+        for (i, cols_per_row) in cols_per_row.enumerate() {
+            if cols_per_row != ncols {
+                let err_msg = format!(
+                    "row {}: expected {} columns, but found {}",
+                    i + 1,
+                    ncols,
+                    cols_per_row);
+                cx.span_err(sp, err_msg[]);
+                return DummyResult::expr(sp);
+            }
+        }
+
+        ncols
+    };
+
+    for (r, row) in matrix.iter().enumerate() {
+        for (c, elem) in row.iter().enumerate() {
+            if elem.is_empty() {
+                cx.span_err(sp, format!("no element found at ({}, {})", r, c)[]);
+                return DummyResult::expr(sp);
+            }
+        }
+    }
+
+    let nelems = nrows * ncols;
+    let mut elems = Vec::with_capacity(nelems);
+    unsafe { elems.set_len(nelems) }
+
+    for (r, row) in matrix.into_iter().enumerate() {
+        for (c, elem) in row.into_iter().enumerate() {
+            let dst = elems.get_mut(c * nrows + r);
+
+            unsafe { ptr::write(dst, cx.new_parser_from_tts(elem).parse_expr()) }
+        }
+    }
+
+    // XXX Ugh, how do I call the existing `vec!` macro here? I'm reinventing the wheel :-(
+    let vec = {
+        let uses = vec![{
+            let segments = vec![
+                token::str_to_ident("std"),
+                token::str_to_ident("slice"),
+                token::str_to_ident("BoxedSlice"),
+            ];
+
+            cx.view_use_simple(sp, Inherited, cx.path_global(sp, segments))
+        }, {
+            let segments = vec![
+                token::str_to_ident("std"),
+                token::str_to_ident("boxed"),
+                token::str_to_ident("HEAP"),
+            ];
+
+            cx.view_use_simple(sp, Inherited, cx.path_global(sp, segments))
+        }];
+
+        let stmts = vec![{
+            let ident = token::str_to_ident("xs");
+            let expr = {
+                let heap = cx.expr_ident(sp, token::str_to_ident("HEAP"));
+                let array = cx.expr_vec(sp, elems);
+
+                cx.expr(sp, ExprBox(heap, array))
+            };
+
+            cx.stmt_let(sp, false, ident, expr)
+        }];
+
+        let expr = Some({
+            let receiver = cx.expr_ident(sp, token::str_to_ident("xs"));
+            let method = token::str_to_ident("into_vec");
+            let args = vec![];
+
+            cx.expr_method_call(sp, receiver, method, args)
+        });
+
+        cx.expr_block(cx.block_all(sp, uses, stmts, expr))
+    };
+
+    if nrows == 1 {
+        let fn_name = {
+            let segments = vec![
+                token::str_to_ident("linalg"),
+                token::str_to_ident("Row"),
+                token::str_to_ident("new"),
+            ];
+
+            cx.expr_path(cx.path_global(sp, segments))
+        };
+        let args = vec![vec];
+
+        MacExpr::new(cx.expr_call(sp, fn_name, args))
+    } else if ncols == 1 {
+        let fn_name = {
+            let segments = vec![
+                token::str_to_ident("linalg"),
+                token::str_to_ident("Col"),
+                token::str_to_ident("new"),
+            ];
+
+            cx.expr_path(cx.path_global(sp, segments))
+        };
+        let args = vec![vec];
+
+        MacExpr::new(cx.expr_call(sp, fn_name, args))
+    } else {
+        let fn_name = {
+            let segments = vec![
+                token::str_to_ident("linalg"),
+                token::str_to_ident("Mat"),
+                token::str_to_ident("new"),
+            ];
+
+            cx.expr_path(cx.path_global(sp, segments))
+        };
+        let args = vec![vec, cx.expr_lit(sp, LitInt(nrows as u64, UnsuffixedIntLit(Plus)))];
+
+        MacExpr::new(cx.expr_call(sp, fn_name, args))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,24 @@
-//! An experimental linear algebra library with OpenBLAS [1] acceleration written in Rust
+//! An experimental linear algebra library with BLAS acceleration written in Rust
 //!
-//! [1] I'm developing this library against OpenBLAS, but since BLAS is a standard, it *should*
-//! work with other BLAS implementations
+//! # Cargo
+//!
+//! - Cargo.toml
+//!
+//! ``` ignore
+//! [dependencies.linalg]
+//! git = "https://github.com/japaric/linalg.rs"
+//!
+//! [dependencies.linalg_macros]
+//! git = "https://github.com/japaric/linalg.rs"
+//! ```
+//!
+//! - Crate file
+//!
+//! ``` ignore
+//! extern crate linalg;
+//! #[phase(plugin)]
+//! extern crate linalg_macros;
+//! ```
 //!
 //! # Conventions
 //!
@@ -237,7 +254,9 @@ impl<T> Col<Vec<T>> {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Col;
     /// assert_eq!(Col::new(vec![0i, 1, 2]), mat![0i; 1; 2])
@@ -257,7 +276,9 @@ impl<T> Col<Vec<T>> {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Col;
     /// assert_eq!(Col::from_fn(3, |i| i), mat![0; 1; 2])
@@ -292,7 +313,9 @@ impl<T> Col<Vec<T>> where T: Clone {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Col;
     /// assert_eq!(Col::from_elem(3, 2), mat![2i; 2; 2])
@@ -314,7 +337,9 @@ impl<T> Col<Vec<T>> where T: Clone + One {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Col;
     /// assert_eq!(Col::ones(3), mat![1i; 1; 1])
@@ -334,7 +359,9 @@ impl<T> Col<Vec<T>> where T: Clone + Zero {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Col;
     /// assert_eq!(Col::zeros(3), mat![0i; 0; 0])
@@ -382,7 +409,9 @@ impl<T> Mat<T> {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Mat;
     /// assert_eq!(Mat::from_fn((2, 2), |i| i), mat![(0, 0), (0, 1); (1, 0), (1, 1)])
@@ -438,7 +467,9 @@ impl<T> Mat<T> where T: Clone {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Mat;
     /// assert_eq!(Mat::from_elem((3, 2), 2), mat![2i, 2; 2, 2; 2, 2])
@@ -465,7 +496,9 @@ impl<T> Mat<T> where T: Clone + One {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Mat;
     /// assert_eq!(Mat::ones((2, 3)), mat![1i, 1, 1; 1, 1, 1])
@@ -485,7 +518,9 @@ impl<T> Mat<T> where T: Clone + One + Zero {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Mat;
     /// assert_eq!(Mat::eye((2, 2)), mat![1i, 0; 0, 1])
@@ -522,7 +557,9 @@ impl<T> Mat<T> where T: Clone + Zero {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Mat;
     /// assert_eq!(Mat::zeros((2, 3)), mat![0i, 0, 0; 0, 0, 0])
@@ -556,7 +593,9 @@ impl<T> Row<Vec<T>> {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Row;
     /// assert_eq!(Row::new(vec![0i, 1, 2]), mat![0i, 1, 2])
@@ -576,7 +615,9 @@ impl<T> Row<Vec<T>> {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Row;
     /// assert_eq!(Row::from_fn(3, |i| i), mat![0, 1, 2])
@@ -611,7 +652,9 @@ impl<T> Row<Vec<T>> where T: Clone {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Row;
     /// assert_eq!(Row::from_elem(3, 2), mat![2i, 2, 2])
@@ -633,7 +676,9 @@ impl<T> Row<Vec<T>> where T: Clone + One {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Row;
     /// assert_eq!(Row::ones(3), mat![1i, 1, 1])
@@ -653,7 +698,9 @@ impl<T> Row<Vec<T>> where T: Clone + Zero {
     /// # Example
     ///
     /// ```
-    /// # #![feature(phase)] #[phase(plugin, link)] extern crate linalg;
+    /// # #![feature(phase)]
+    /// # extern crate linalg;
+    /// # #[phase(plugin)] extern crate linalg_macros;
     /// # fn main() {
     /// # use linalg::Row;
     /// assert_eq!(Row::zeros(3), mat![0i, 0, 0])
@@ -674,66 +721,4 @@ impl<T> Row<Vec<T>> where T: Rand {
 
         Row(Vec::from_fn(length, |_| rng.gen()))
     }
-}
-
-#[doc(hidden)]
-#[macro_export]
-// TODO (rust-lang/rfcs#88) Replace this macro with the `$#(..)` syntax
-macro_rules! count_args {
-    ($x:expr) => {
-        1
-    };
-    ($x:expr, $($xs:expr),+) => {
-        1 + count_args!($($xs),+)
-    }
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! push_columns {
-    ($data:expr <- $($e:expr);+) => ({
-        $($data.push($e);)+
-    });
-    ($data:expr <- $($x:expr, $($xs:expr),+);+) => ({
-        $($data.push($x);)+
-        push_columns!($data <- $($($xs),+);+)
-    });
-}
-
-/// Creates an owned row/column vector or matrix from the arguments
-#[macro_export]
-macro_rules! mat {
-    // Row vector: mat![0, 1, 2]
-    ($x:expr, $($xs:expr),+) => ({
-        let mut data = Vec::with_capacity(count_args!($x, $($xs),+));
-        data.push($x);
-        $(data.push($xs);)+
-
-        ::linalg::Row::new(data)
-    });
-    // Column vector: mat![0; 1; 2]
-    ($x:expr; $($xs:expr);+) => ({
-        let mut data = Vec::with_capacity(count_args!($x, $($xs),+));
-        data.push($x);
-        $(data.push($xs);)+
-
-        ::linalg::Col::new(data)
-    });
-    // Owned matrix: mat![0, 1, 2; 3, 4, 5]
-    ($x:expr, $($xs:expr),+; $($y:expr, $($ys:expr),+);+) => ({
-        let nrows = count_args!($x, $($y),+);
-        let ncols = count_args!($x, $($xs),+);
-
-        // FIXME This should be a compiler error
-        assert!($(ncols == count_args!($y, $($ys),+))&&+);
-
-        let mut data = Vec::with_capacity(nrows * ncols);
-        push_columns!(data <- $x, $($xs),+; $($y, $($ys),+);+)
-
-        ::linalg::Mat::new(data, nrows)
-    });
-    // Trailing semicolon
-    ($($($e:expr),+);+;) => {
-        mat![$($($e),+);+]
-    };
 }


### PR DESCRIPTION
The new `mat!` expansion does much less work at runtime.

If you were using the `mat!` macro, you'll have to change your crate linking
from:

```
#[phase(link, plugin)]
extern crate linalg;
```

to

```
extern crate linalg;
#[phase(plugin)]
extern crate linalg_macros;
```

[breaking-change]
