### PR TITLE
refactor: use associated types

### DIFF
--- a/src/add.rs
+++ b/src/add.rs
@@ -9,6 +9,7 @@ macro_rules! add0 {
     ($lhs:ty, $rhs:ty) => {
         impl<T> Add<$rhs> for $lhs where T: Axpy + One {
             type Output = $lhs;
+
             fn add(mut self, rhs: $rhs) -> $lhs {
                 self.add_assign(rhs);
                 self
@@ -17,6 +18,7 @@ macro_rules! add0 {
 
         impl<T> Add<$lhs> for $rhs where T: Axpy + One {
             type Output = $lhs;
+
             fn add(self, rhs: $lhs) -> $lhs {
                 rhs + self
             }
@@ -28,6 +30,7 @@ macro_rules! add1 {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, T> Add<$rhs> for $lhs where T: Axpy + One {
             type Output = $lhs;
+
             fn add(mut self, rhs: $rhs) -> $lhs {
                 self.add_assign(rhs);
                 self
@@ -36,6 +39,7 @@ macro_rules! add1 {
 
         impl<'a, T> Add<$lhs> for $rhs where T: Axpy + One {
             type Output = $lhs;
+
             fn add(self, rhs: $lhs) -> $lhs {
                 rhs + self
             }
@@ -47,6 +51,7 @@ macro_rules! add1c {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, T> Add<$rhs> for $lhs where T: Axpy + One + Clone {
             type Output = $lhs;
+
             fn add(mut self, rhs: $rhs) -> $lhs {
                 self.add_assign(rhs);
                 self
@@ -55,6 +60,7 @@ macro_rules! add1c {
 
         impl<'a, T> Add<$lhs> for $rhs where T: Axpy + One + Clone {
             type Output = $lhs;
+
             fn add(self, rhs: $lhs) -> $lhs {
                 rhs + self
             }
@@ -66,6 +72,7 @@ macro_rules! add2 {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, 'b, T> Add<$rhs> for $lhs where T: Axpy + One {
             type Output = $lhs;
+
             fn add(mut self, rhs: $rhs) -> $lhs {
                 self.add_assign(rhs);
                 self
@@ -74,6 +81,7 @@ macro_rules! add2 {
 
         impl<'a, 'b, T> Add<$lhs> for $rhs where T: Axpy + One {
             type Output = $lhs;
+
             fn add(self, rhs: $lhs) -> $lhs {
                 rhs + self
             }
@@ -85,6 +93,7 @@ macro_rules! add2c {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, 'b, T> Add<$rhs> for $lhs where T: Axpy + Clone + One {
             type Output = $lhs;
+
             fn add(mut self, rhs: $rhs) -> $lhs {
                 self.add_assign(rhs);
                 self
@@ -93,6 +102,7 @@ macro_rules! add2c {
 
         impl<'a, 'b, T> Add<$lhs> for $rhs where T: Axpy + Clone + One {
             type Output = $lhs;
+
             fn add(self, rhs: $lhs) -> $lhs {
                 rhs + self
             }
@@ -104,6 +114,7 @@ macro_rules! add3 {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, 'b, 'c, T> Add<$rhs> for $lhs where T: Axpy + One {
             type Output = $lhs;
+
             fn add(mut self, rhs: $rhs) -> $lhs {
                 self.add_assign(rhs);
                 self
@@ -112,6 +123,7 @@ macro_rules! add3 {
 
         impl<'a, 'b, 'c, T> Add<$lhs> for $rhs where T: Axpy + One {
             type Output = $lhs;
+
             fn add(self, rhs: $lhs) -> $lhs {
                 rhs + self
             }

--- a/src/at.rs
+++ b/src/at.rs
@@ -4,7 +4,9 @@ use error::OutOfBounds;
 use traits::{At, AtMut};
 use {Col, ColVec, Diag, Mat, MutCol, MutDiag, MutRow, MutView, Row, RowVec, View};
 
-impl<T> ::At<uint, T> for [T] {
+impl<T> ::At<uint> for [T] {
+    type Output = T;
+
     fn at(&self, index: uint) -> Result<&T, OutOfBounds> {
         if index < self.len() {
             Ok(unsafe { mem::transmute(self.as_ptr().offset(index as int)) })
@@ -14,25 +16,33 @@ impl<T> ::At<uint, T> for [T] {
     }
 }
 
-impl<'a, T> At<uint, T> for Col<'a, T> {
+impl<'a, T> At<uint> for Col<'a, T> {
+    type Output = T;
+
     fn at(&self, index: uint) -> Result<&T, OutOfBounds> {
         self.0.at(index)
     }
 }
 
-impl<T> At<uint, T> for ColVec<T> {
+impl<T> At<uint> for ColVec<T> {
+    type Output = T;
+
     fn at(&self, index: uint) -> Result<&T, OutOfBounds> {
         ::At::at(&*self.0, index)
     }
 }
 
-impl<'a, T> At<uint, T> for Diag<'a, T> {
+impl<'a, T> At<uint> for Diag<'a, T> {
+    type Output = T;
+
     fn at(&self, index: uint) -> Result<&T, OutOfBounds> {
         self.0.at(index)
     }
 }
 
-impl<T> At<(uint, uint), T> for Mat<T> {
+impl<T> At<(uint, uint)> for Mat<T> {
+    type Output = T;
+
     fn at(&self, (row, col): (uint, uint)) -> Result<&T, OutOfBounds> {
         let (nrows, ncols) = (self.nrows, self.ncols);
 
@@ -44,85 +54,113 @@ impl<T> At<(uint, uint), T> for Mat<T> {
     }
 }
 
-impl<'a, T> At<uint, T> for MutCol<'a, T> {
+impl<'a, T> At<uint> for MutCol<'a, T> {
+    type Output = T;
+
     fn at(&self, index: uint) -> Result<&T, OutOfBounds> {
         self.0.at(index)
     }
 }
 
-impl<'a, T> At<uint, T> for MutDiag<'a, T> {
+impl<'a, T> At<uint> for MutDiag<'a, T> {
+    type Output = T;
+
     fn at(&self, index: uint) -> Result<&T, OutOfBounds> {
         self.0.at(index)
     }
 }
 
-impl<'a, T> At<uint, T> for MutRow<'a, T> {
+impl<'a, T> At<uint> for MutRow<'a, T> {
+    type Output = T;
+
     fn at(&self, index: uint) -> Result<&T, OutOfBounds> {
         self.0.at(index)
     }
 }
 
-impl<'a, T> At<(uint, uint), T> for MutView<'a, T> {
+impl<'a, T> At<(uint, uint)> for MutView<'a, T> {
+    type Output = T;
+
     fn at(&self, (row, col): (uint, uint)) -> Result<&T, OutOfBounds> {
         self.0.at((row, col))
     }
 }
 
-impl<'a, T> At<uint, T> for Row<'a, T> {
+impl<'a, T> At<uint> for Row<'a, T> {
+    type Output = T;
+
     fn at(&self, index: uint) -> Result<&T, OutOfBounds> {
         self.0.at(index)
     }
 }
 
-impl<T> At<uint, T> for RowVec<T> {
+impl<T> At<uint> for RowVec<T> {
+    type Output = T;
+
     fn at(&self, index: uint) -> Result<&T, OutOfBounds> {
         ::At::at(&*self.0, index)
     }
 }
 
-impl<'a, T> At<(uint, uint), T> for View<'a, T> {
+impl<'a, T> At<(uint, uint)> for View<'a, T> {
+    type Output = T;
+
     fn at(&self, (row, col): (uint, uint)) -> Result<&T, OutOfBounds> {
         self.0.at((row, col))
     }
 }
 
-impl<T> AtMut<uint, T> for ColVec<T> {
+impl<T> AtMut<uint> for ColVec<T> {
+    type Output = T;
+
     fn at_mut(&mut self, index: uint) -> Result<&mut T, OutOfBounds> {
         unsafe { mem::transmute(::At::at(&*self.0, index)) }
     }
 }
 
-impl<T> AtMut<(uint, uint), T> for Mat<T> {
+impl<T> AtMut<(uint, uint)> for Mat<T> {
+    type Output = T;
+
     fn at_mut(&mut self, (row, col): (uint, uint)) -> Result<&mut T, OutOfBounds> {
         unsafe { mem::transmute(self.at((row, col))) }
     }
 }
 
-impl<'a, T> AtMut<uint, T> for MutCol<'a, T> {
+impl<'a, T> AtMut<uint> for MutCol<'a, T> {
+    type Output = T;
+
     fn at_mut(&mut self, index: uint) -> Result<&mut T, OutOfBounds> {
         self.0.at_mut(index)
     }
 }
 
-impl<'a, T> AtMut<uint, T> for MutDiag<'a, T> {
+impl<'a, T> AtMut<uint> for MutDiag<'a, T> {
+    type Output = T;
+
     fn at_mut(&mut self, index: uint) -> Result<&mut T, OutOfBounds> {
         self.0.at_mut(index)
     }
 }
 
-impl<'a, T> AtMut<uint, T> for MutRow<'a, T> {
+impl<'a, T> AtMut<uint> for MutRow<'a, T> {
+    type Output = T;
+
     fn at_mut(&mut self, index: uint) -> Result<&mut T, OutOfBounds> {
         self.0.at_mut(index)
     }
 }
 
-impl<'a, T> AtMut<(uint, uint), T> for MutView<'a, T> {
+impl<'a, T> AtMut<(uint, uint)> for MutView<'a, T> {
+    type Output = T;
+
     fn at_mut(&mut self, (row, col): (uint, uint)) -> Result<&mut T, OutOfBounds> {
         unsafe { mem::transmute(self.0.at((row, col))) }
     }
 }
 
-impl<T> AtMut<uint, T> for RowVec<T> {
+impl<T> AtMut<uint> for RowVec<T> {
+    type Output = T;
+
     fn at_mut(&mut self, index: uint) -> Result<&mut T, OutOfBounds> {
         unsafe { mem::transmute(::At::at(&*self.0, index)) }
     }

--- a/src/col.rs
+++ b/src/col.rs
@@ -2,6 +2,8 @@ use traits::{Matrix, Transpose};
 use {Col, MutCol, MutRow, Row};
 
 impl<'a, T> Matrix for MutCol<'a, T> {
+    type Elem = T;
+
     fn ncols(&self) -> uint {
         1
     }
@@ -11,13 +13,17 @@ impl<'a, T> Matrix for MutCol<'a, T> {
     }
 }
 
-impl<'a, T> Transpose<MutRow<'a, T>> for MutCol<'a, T> {
+impl<'a, T> Transpose for MutCol<'a, T> {
+    type Output = MutRow<'a, T>;
+
     fn t(self) -> MutRow<'a, T> {
         MutRow(self.0)
     }
 }
 
 impl<'a, T> Matrix for Col<'a, T> {
+    type Elem = T;
+
     fn ncols(&self) -> uint {
         1
     }
@@ -27,7 +33,9 @@ impl<'a, T> Matrix for Col<'a, T> {
     }
 }
 
-impl<'a, T> Transpose<Row<'a, T>> for Col<'a, T> {
+impl<'a, T> Transpose for Col<'a, T> {
+    type Output = Row<'a, T>;
+
     fn t(self) -> Row<'a, T> {
         Row(self.0)
     }

--- a/src/cols.rs
+++ b/src/cols.rs
@@ -3,13 +3,13 @@ use std::mem;
 use traits::{MatrixCol, MatrixColMut};
 use {Col, Cols, MutCol, MutCols};
 
-impl<'a, T, M> DoubleEndedIterator for Cols<'a, M> where M: MatrixCol<T> {
+impl<'a, T, M> DoubleEndedIterator for Cols<'a, M> where M: MatrixCol<Elem=T> {
     fn next_back(&mut self) -> Option<Col<'a, T>> {
         self.0.next_back()
     }
 }
 
-impl<'a, T, M> Iterator for Cols<'a, M> where M: MatrixCol<T> {
+impl<'a, T, M> Iterator for Cols<'a, M> where M: MatrixCol<Elem=T> {
     type Item = Col<'a, T>;
 
     fn next(&mut self) -> Option<Col<'a, T>> {
@@ -21,13 +21,13 @@ impl<'a, T, M> Iterator for Cols<'a, M> where M: MatrixCol<T> {
     }
 }
 
-impl<'a, T, M> DoubleEndedIterator for MutCols<'a, M> where M: MatrixColMut<T> {
+impl<'a, T, M> DoubleEndedIterator for MutCols<'a, M> where M: MatrixColMut<Elem=T> {
     fn next_back(&mut self) -> Option<MutCol<'a, T>> {
         unsafe { mem::transmute(self.0.next_back()) }
     }
 }
 
-impl<'a, T, M> Iterator for MutCols<'a, M> where M: MatrixColMut<T> {
+impl<'a, T, M> Iterator for MutCols<'a, M> where M: MatrixColMut<Elem=T> {
     type Item = MutCol<'a, T>;
 
     fn next(&mut self) -> Option<MutCol<'a, T>> {

--- a/src/cols.rs
+++ b/src/cols.rs
@@ -11,6 +11,7 @@ impl<'a, T, M> DoubleEndedIterator for Cols<'a, M> where M: MatrixCol<T> {
 
 impl<'a, T, M> Iterator for Cols<'a, M> where M: MatrixCol<T> {
     type Item = Col<'a, T>;
+
     fn next(&mut self) -> Option<Col<'a, T>> {
         self.0.next()
     }
@@ -28,6 +29,7 @@ impl<'a, T, M> DoubleEndedIterator for MutCols<'a, M> where M: MatrixColMut<T> {
 
 impl<'a, T, M> Iterator for MutCols<'a, M> where M: MatrixColMut<T> {
     type Item = MutCol<'a, T>;
+
     fn next(&mut self) -> Option<MutCol<'a, T>> {
         unsafe { mem::transmute(self.0.next()) }
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -4,19 +4,25 @@ use strided;
 use traits::{Iter, IterMut};
 use {Col, ColVec, Diag, Mat, MutCol, MutDiag, MutRow, Row, RowVec};
 
-impl<'a, T> Iter<'a, &'a T, slice::Iter<'a, T>> for ColVec<T> {
+impl<'a, T> Iter<'a> for ColVec<T> {
+    type Iter = slice::Iter<'a, T>;
+
     fn iter(&'a self) -> slice::Iter<'a, T> {
         self.0.iter()
     }
 }
 
-impl<'a, T> Iter<'a, &'a T, slice::Iter<'a, T>> for Mat<T> {
+impl<'a, T> Iter<'a> for Mat<T> {
+    type Iter = slice::Iter<'a, T>;
+
     fn iter(&'a self) -> slice::Iter<'a, T> {
         self.data.iter()
     }
 }
 
-impl<'a, T> Iter<'a, &'a T, slice::Iter<'a, T>> for RowVec<T> {
+impl<'a, T> Iter<'a> for RowVec<T> {
+    type Iter = slice::Iter<'a, T>;
+
     fn iter(&'a self) -> slice::Iter<'a, T> {
         self.0.iter()
     }
@@ -25,7 +31,9 @@ impl<'a, T> Iter<'a, &'a T, slice::Iter<'a, T>> for RowVec<T> {
 macro_rules! impls {
     ($($ty:ty),+) => {
         $(
-            impl<'a, 'b, T> Iter<'a, &'a T, strided::Items<'a, T>> for $ty {
+            impl<'a, 'b, T> Iter<'a> for $ty {
+                type Iter = strided::Items<'a, T>;
+
                 fn iter(&'a self) -> strided::Items<'a, T> {
                     self.0.iter()
                 }
@@ -36,19 +44,25 @@ macro_rules! impls {
 
 impls!(Col<'b, T>, Diag<'b, T>, MutCol<'b, T>, MutDiag<'b, T>, MutRow<'b, T>, Row<'b, T>);
 
-impl<'a, T> IterMut<'a, &'a mut T, slice::IterMut<'a, T>> for ColVec<T> {
+impl<'a, T> IterMut<'a> for ColVec<T> {
+    type Iter = slice::IterMut<'a, T>;
+
     fn iter_mut(&'a mut self) -> slice::IterMut<'a, T> {
         self.0.iter_mut()
     }
 }
 
-impl<'a, T> IterMut<'a, &'a mut T, slice::IterMut<'a, T>> for Mat<T> {
+impl<'a, T> IterMut<'a> for Mat<T> {
+    type Iter = slice::IterMut<'a, T>;
+
     fn iter_mut(&'a mut self) -> slice::IterMut<'a, T> {
         self.data.iter_mut()
     }
 }
 
-impl<'a, T> IterMut<'a, &'a mut T, slice::IterMut<'a, T>> for RowVec<T> {
+impl<'a, T> IterMut<'a> for RowVec<T> {
+    type Iter = slice::IterMut<'a, T>;
+
     fn iter_mut(&'a mut self) -> slice::IterMut<'a, T> {
         self.0.iter_mut()
     }
@@ -57,7 +71,9 @@ impl<'a, T> IterMut<'a, &'a mut T, slice::IterMut<'a, T>> for RowVec<T> {
 macro_rules! impls_mut {
     ($($ty:ty),+) => {
         $(
-            impl<'a, 'b, T> IterMut<'a, &'a mut T, strided::MutItems<'a, T>> for $ty {
+            impl<'a, 'b, T> IterMut<'a> for $ty {
+                type Iter = strided::MutItems<'a, T>;
+
                 fn iter_mut(&'a mut self) -> strided::MutItems<'a, T> {
                     self.0.iter_mut()
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -665,7 +665,7 @@ pub enum Error {
 // Private versions of `traits::{At, Slice}` to not expose implementations on stdlib types
 // XXX Why do I have to document private traits?
 /// Private
-trait At<I> for Sized? {
+trait At<I> {
     type Output;
 
     /// private
@@ -673,7 +673,7 @@ trait At<I> for Sized? {
 }
 
 /// Private
-trait Slice<'a, I> for Sized? {
+trait Slice<'a, I> {
     type Slice;
 
     /// Private

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -665,15 +665,19 @@ pub enum Error {
 // Private versions of `traits::{At, Slice}` to not expose implementations on stdlib types
 // XXX Why do I have to document private traits?
 /// Private
-trait At<I, T> for Sized? {
+trait At<I> for Sized? {
+    type Output;
+
     /// private
-    fn at(&self, I) -> std::result::Result<&T, error::OutOfBounds>;
+    fn at(&self, I) -> std::result::Result<&Self::Output, error::OutOfBounds>;
 }
 
 /// Private
-trait Slice<'a, I, S> for Sized? {
+trait Slice<'a, I> for Sized? {
+    type Slice;
+
     /// Private
-    fn slice(&'a self, start: I, end: I) -> Result<S>;
+    fn slice(&'a self, start: I, end: I) -> Result<Self::Slice>;
 }
 
 // FIXME Use `cast.rs` instead of this trait

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -7,11 +7,13 @@ use traits::{
 };
 
 impl<T> Matrix for Mat<T> {
+    type Elem = T;
+
     fn ncols(&self) -> uint { self.ncols }
     fn nrows(&self) -> uint { self.nrows }
 }
 
-impl<T> MatrixCol<T> for Mat<T> {
+impl<T> MatrixCol for Mat<T> {
     unsafe fn unsafe_col(&self, col: uint) -> Col<T> {
         Col(::From::parts((
             self.data.as_ptr().offset((col * self.nrows()) as int),
@@ -21,7 +23,7 @@ impl<T> MatrixCol<T> for Mat<T> {
     }
 }
 
-impl<T> MatrixColMut<T> for Mat<T> {
+impl<T> MatrixColMut for Mat<T> {
     unsafe fn unsafe_col_mut(&mut self, col: uint) -> MutCol<T> {
         mem::transmute(self.unsafe_col(col))
     }
@@ -29,7 +31,7 @@ impl<T> MatrixColMut<T> for Mat<T> {
 
 impl<T> MatrixCols for Mat<T> {}
 
-impl<T> MatrixDiag<T> for Mat<T> {
+impl<T> MatrixDiag for Mat<T> {
     fn diag(&self, diag: int) -> Result<Diag<T>> {
         let (nrows, ncols) = (self.nrows, self.ncols);
         let stride = nrows;
@@ -60,7 +62,7 @@ impl<T> MatrixDiag<T> for Mat<T> {
     }
 }
 
-impl<T> MatrixDiagMut<T> for Mat<T> {
+impl<T> MatrixDiagMut for Mat<T> {
     fn diag_mut(&mut self, diag: int) -> Result<MutDiag<T>> {
         unsafe { mem::transmute(self.diag(diag)) }
     }
@@ -70,7 +72,7 @@ impl<T> MatrixMutCols for Mat<T> {}
 
 impl<T> MatrixMutRows for Mat<T> {}
 
-impl<T> MatrixRow<T> for Mat<T> {
+impl<T> MatrixRow for Mat<T> {
     unsafe fn unsafe_row(&self, row: uint) -> Row<T> {
         let (nrows, ncols) = self.size();
 
@@ -82,7 +84,7 @@ impl<T> MatrixRow<T> for Mat<T> {
     }
 }
 
-impl<T> MatrixRowMut<T> for Mat<T> {
+impl<T> MatrixRowMut for Mat<T> {
     unsafe fn unsafe_row_mut(&mut self, row: uint) -> MutRow<T> {
         mem::transmute(self.unsafe_row(row))
     }

--- a/src/mul.rs
+++ b/src/mul.rs
@@ -46,6 +46,7 @@ fn mc<T>(
 
 impl<'a, 'b, T> Mul<Col<'a, T>> for &'b Mat<T> where T: Gemv + One + Zero {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: Col<T>) -> ColVec<T> {
         self.as_view() * rhs
     }
@@ -53,6 +54,7 @@ impl<'a, 'b, T> Mul<Col<'a, T>> for &'b Mat<T> where T: Gemv + One + Zero {
 
 impl<'a, 'b, T> Mul<&'a ColVec<T>> for &'b Mat<T> where T: Gemv + One + Zero {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &ColVec<T>) -> ColVec<T> {
         self.as_view() * rhs.as_col()
     }
@@ -62,6 +64,7 @@ impl<'a, 'b, 'c, T> Mul<&'a MutCol<'b, T>> for &'c Mat<T> where
     T: Gemv + One + Zero,
 {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &MutCol<T>) -> ColVec<T> {
         self.as_view() * rhs.as_col()
     }
@@ -69,6 +72,7 @@ impl<'a, 'b, 'c, T> Mul<&'a MutCol<'b, T>> for &'c Mat<T> where
 
 impl<'a, 'b, 'c, T> Mul<Col<'a, T>> for &'b MutView<'c, T> where T: Gemv + One + Zero {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: Col<T>) -> ColVec<T> {
         self.as_view() * rhs
     }
@@ -78,6 +82,7 @@ impl<'a, 'b, 'c, T> Mul<&'a ColVec<T>> for &'b MutView<'c, T> where
     T: Gemv + One + Zero,
 {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &ColVec<T>) -> ColVec<T> {
         self.as_view() * rhs.as_col()
     }
@@ -87,6 +92,7 @@ impl<'a, 'b, 'c, 'd, T> Mul<&'a MutCol<'b, T>> for &'c MutView<'d, T> where
     T: Gemv + One + Zero,
 {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &MutCol<T>) -> ColVec<T> {
         self.as_view() * rhs.as_col()
     }
@@ -96,6 +102,7 @@ impl<'a, 'b, T> Mul<Col<'a, T>> for &'b Trans<Mat<T>> where
     T: Gemv + One + Zero,
 {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: Col<T>) -> ColVec<T> {
         Trans(self.0.as_view()) * rhs
     }
@@ -105,6 +112,7 @@ impl<'a, 'b, T> Mul<&'a ColVec<T>> for &'b Trans<Mat<T>> where
     T: Gemv + One + Zero,
 {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &ColVec<T>) -> ColVec<T> {
         Trans(self.0.as_view()) * rhs.as_col()
     }
@@ -114,6 +122,7 @@ impl<'a, 'b, 'c, T> Mul<&'a MutCol<'b, T>> for &'c Trans<Mat<T>> where
     T: Gemv + One + Zero,
 {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &MutCol<T>) -> ColVec<T> {
         Trans(self.0.as_view()) * rhs.as_col()
     }
@@ -123,6 +132,7 @@ impl<'a, 'b, 'c, T> Mul<Col<'a, T>> for &'b Trans<MutView<'c, T>> where
     T: Gemv + One + Zero,
 {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: Col<T>) -> ColVec<T> {
         Trans(self.0.as_view())* rhs
     }
@@ -132,6 +142,7 @@ impl<'a, 'b, 'c, T> Mul<&'a ColVec<T>> for &'b Trans<MutView<'c, T>> where
     T: Gemv + One + Zero,
 {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &ColVec<T>) -> ColVec<T> {
         Trans(self.0.as_view())* rhs.as_col()
     }
@@ -141,6 +152,7 @@ impl<'a, 'b, 'c, 'd, T> Mul<&'a MutCol<'b, T>> for &'c Trans<MutView<'d, T>> whe
     T: Gemv + One + Zero,
 {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &MutCol<T>) -> ColVec<T> {
         Trans(self.0.as_view())* rhs.as_col()
     }
@@ -148,6 +160,7 @@ impl<'a, 'b, 'c, 'd, T> Mul<&'a MutCol<'b, T>> for &'c Trans<MutView<'d, T>> whe
 
 impl<'a, 'b, T> Mul<Col<'a, T>> for Trans<View<'b, T>> where T: Gemv + One + Zero {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: Col<T>) -> ColVec<T> {
         let lhs = self;
 
@@ -160,6 +173,7 @@ impl<'a, 'b, T> Mul<Col<'a, T>> for Trans<View<'b, T>> where T: Gemv + One + Zer
 
 impl<'a, 'b, T> Mul<&'a ColVec<T>> for Trans<View<'b, T>> where T: Gemv + One + Zero {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &ColVec<T>) -> ColVec<T> {
         self * rhs.as_col()
     }
@@ -169,6 +183,7 @@ impl<'a, 'b, 'c, T> Mul<&'a MutCol<'b, T>> for Trans<View<'c, T>> where
     T: Gemv + One + Zero,
 {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &MutCol<T>) -> ColVec<T> {
         self * rhs.as_col()
     }
@@ -176,6 +191,7 @@ impl<'a, 'b, 'c, T> Mul<&'a MutCol<'b, T>> for Trans<View<'c, T>> where
 
 impl<'a, 'b, T> Mul<Col<'a, T>> for View<'b, T> where T: Gemv + One + Zero {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: Col<T>) -> ColVec<T> {
         let lhs = self;
 
@@ -188,6 +204,7 @@ impl<'a, 'b, T> Mul<Col<'a, T>> for View<'b, T> where T: Gemv + One + Zero {
 
 impl<'a, 'b, T> Mul<&'a ColVec<T>> for View<'b, T> where T: Gemv + One + Zero {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &ColVec<T>) -> ColVec<T> {
         self * rhs.as_col()
     }
@@ -195,6 +212,7 @@ impl<'a, 'b, T> Mul<&'a ColVec<T>> for View<'b, T> where T: Gemv + One + Zero {
 
 impl<'a, 'b, 'c, T> Mul<&'a MutCol<'b, T>> for View<'c, T> where T: Gemv + One + Zero {
     type Output = ColVec<T>;
+
     fn mul(self, rhs: &MutCol<T>) -> ColVec<T> {
         self * rhs.as_col()
     }
@@ -249,6 +267,7 @@ fn mm<T>(
 
 impl<'a, 'b, T> Mul<&'a Mat<T>> for &'b Mat<T> where T: Gemm + One + Zero {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Mat<T>) -> Mat<T> {
         self.as_view() * rhs.as_view()
     }
@@ -258,6 +277,7 @@ impl<'a, 'b, 'c, T> Mul<&'a MutView<'b, T>> for &'c Mat<T> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &MutView<T>) -> Mat<T> {
         self.as_view() * rhs.as_view()
     }
@@ -267,6 +287,7 @@ impl<'a, 'b, T> Mul<&'a Trans<Mat<T>>> for &'b Mat<T> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<Mat<T>>) -> Mat<T> {
         self.as_view() * Trans(rhs.0.as_view())
     }
@@ -276,6 +297,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Trans<MutView<'b, T>>> for &'c Mat<T> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<MutView<T>>) -> Mat<T> {
         self.as_view() * Trans(rhs.0.as_view())
     }
@@ -285,6 +307,7 @@ impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for &'b Mat<T> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: Trans<View<T>>) -> Mat<T> {
         self.as_view() * rhs
     }
@@ -292,6 +315,7 @@ impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for &'b Mat<T> where
 
 impl<'a, 'b, T> Mul<View<'a, T>> for &'b Mat<T> where T: Gemm + One + Zero {
     type Output = Mat<T>;
+
     fn mul(self, rhs: View<T>) -> Mat<T> {
         self.as_view() * rhs
     }
@@ -299,6 +323,7 @@ impl<'a, 'b, T> Mul<View<'a, T>> for &'b Mat<T> where T: Gemm + One + Zero {
 
 impl<'a, 'b, 'c, T> Mul<&'a Mat<T>> for &'b MutView<'c, T> where T: Gemm + One + Zero {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Mat<T>) -> Mat<T> {
         self.as_view() * rhs.as_view()
     }
@@ -308,6 +333,7 @@ impl<'a, 'b, 'c, 'd, T> Mul<&'a MutView<'b, T>> for &'c MutView<'d, T> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &MutView<T>) -> Mat<T> {
         self.as_view() * rhs.as_view()
     }
@@ -317,6 +343,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Trans<Mat<T>>> for &'b MutView<'c, T> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<Mat<T>>) -> Mat<T> {
         self.as_view() * Trans(rhs.0.as_view())
     }
@@ -326,6 +353,7 @@ impl<'a, 'b, 'c, 'd, T> Mul<&'a Trans<MutView<'b, T>>> for &'c MutView<'d, T> wh
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<MutView<T>>) -> Mat<T> {
         self.as_view() * Trans(rhs.0.as_view())
     }
@@ -335,6 +363,7 @@ impl<'a, 'b, 'c, T> Mul<Trans<View<'a, T>>> for &'b MutView<'c, T> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: Trans<View<T>>) -> Mat<T> {
         self.as_view() * rhs
     }
@@ -342,6 +371,7 @@ impl<'a, 'b, 'c, T> Mul<Trans<View<'a, T>>> for &'b MutView<'c, T> where
 
 impl<'a, 'b, 'c, T> Mul<View<'a, T>> for &'b MutView<'c, T> where T: Gemm + One + Zero {
     type Output = Mat<T>;
+
     fn mul(self, rhs: View<T>) -> Mat<T> {
         self.as_view() * rhs
     }
@@ -349,6 +379,7 @@ impl<'a, 'b, 'c, T> Mul<View<'a, T>> for &'b MutView<'c, T> where T: Gemm + One 
 
 impl<'a, 'b, T> Mul<&'a Mat<T>> for &'b Trans<Mat<T>> where T: Gemm + One + Zero {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Mat<T>) -> Mat<T> {
         Trans(self.0.as_view()) * rhs.as_view()
     }
@@ -358,6 +389,7 @@ impl<'a, 'b, 'c, T> Mul<&'a MutView<'b, T>> for &'c Trans<Mat<T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &MutView<T>) -> Mat<T> {
         Trans(self.0.as_view()) * rhs.as_view()
     }
@@ -367,6 +399,7 @@ impl<'a, 'b, T> Mul<&'a Trans<Mat<T>>> for &'b Trans<Mat<T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<Mat<T>>) -> Mat<T> {
         Trans(self.0.as_view()) * Trans(rhs.0.as_view())
     }
@@ -376,6 +409,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Trans<MutView<'b, T>>> for &'c Trans<Mat<T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<MutView<T>>) -> Mat<T> {
         Trans(self.0.as_view()) * Trans(rhs.0.as_view())
     }
@@ -385,6 +419,7 @@ impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for &'b Trans<Mat<T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: Trans<View<T>>) -> Mat<T> {
         Trans(self.0.as_view()) * rhs
     }
@@ -392,6 +427,7 @@ impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for &'b Trans<Mat<T>> where
 
 impl<'a, 'b, T> Mul<View<'a, T>> for &'b Trans<Mat<T>> where T: Gemm + One + Zero {
     type Output = Mat<T>;
+
     fn mul(self, rhs: View<T>) -> Mat<T> {
         Trans(self.0.as_view()) * rhs
     }
@@ -401,6 +437,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Mat<T>> for &'b Trans<MutView<'c, T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Mat<T>) -> Mat<T> {
         Trans(self.0.as_view()) * rhs.as_view()
     }
@@ -410,6 +447,7 @@ impl<'a, 'b, 'c, 'd, T> Mul<&'a MutView<'b, T>> for &'c Trans<MutView<'d, T>> wh
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &MutView<T>) -> Mat<T> {
         Trans(self.0.as_view()) * rhs.as_view()
     }
@@ -419,6 +457,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Trans<Mat<T>>> for &'b Trans<MutView<'c, T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<Mat<T>>) -> Mat<T> {
         Trans(self.0.as_view()) * Trans(rhs.0.as_view())
     }
@@ -428,6 +467,7 @@ impl<'a, 'b, 'c, 'd, T> Mul<&'a Trans<MutView<'b, T>>> for &'c Trans<MutView<'d,
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<MutView<T>>) -> Mat<T> {
         Trans(self.0.as_view()) * Trans(rhs.0.as_view())
     }
@@ -437,6 +477,7 @@ impl<'a, 'b, 'c, T> Mul<Trans<View<'a, T>>> for &'b Trans<MutView<'c, T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: Trans<View<T>>) -> Mat<T> {
         Trans(self.0.as_view()) * rhs
     }
@@ -446,6 +487,7 @@ impl<'a, 'b, 'c, T> Mul<View<'a, T>> for &'b Trans<MutView<'c, T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: View<T>) -> Mat<T> {
         Trans(self.0.as_view()) * rhs
     }
@@ -453,6 +495,7 @@ impl<'a, 'b, 'c, T> Mul<View<'a, T>> for &'b Trans<MutView<'c, T>> where
 
 impl<'a, 'b, T> Mul<&'a Mat<T>> for Trans<View<'b, T>> where T: Gemm + One + Zero {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Mat<T>) -> Mat<T> {
         self * rhs.as_view()
     }
@@ -462,6 +505,7 @@ impl<'a, 'b, 'c, T> Mul<&'a MutView<'b, T>> for Trans<View<'c, T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &MutView<T>) -> Mat<T> {
         self * rhs.as_view()
     }
@@ -471,6 +515,7 @@ impl<'a, 'b, T> Mul<&'a Trans<Mat<T>>> for Trans<View<'b, T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<Mat<T>>) -> Mat<T> {
         self * Trans(rhs.0.as_view())
     }
@@ -480,6 +525,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Trans<MutView<'b, T>>> for Trans<View<'c, T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<MutView<T>>) -> Mat<T> {
         self * Trans(rhs.0.as_view())
     }
@@ -489,6 +535,7 @@ impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for Trans<View<'b, T>> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: Trans<View<T>>) -> Mat<T> {
         let lhs = self;
 
@@ -501,6 +548,7 @@ impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for Trans<View<'b, T>> where
 
 impl<'a, 'b, T> Mul<View<'a, T>> for Trans<View<'b, T>> where T: Gemm + One + Zero {
     type Output = Mat<T>;
+
     fn mul(self, rhs: View<T>) -> Mat<T> {
         let lhs = self;
 
@@ -513,6 +561,7 @@ impl<'a, 'b, T> Mul<View<'a, T>> for Trans<View<'b, T>> where T: Gemm + One + Ze
 
 impl<'a, 'b, T> Mul<&'a Mat<T>> for View<'b, T> where T: Gemm + One + Zero {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Mat<T>) -> Mat<T> {
         self * rhs.as_view()
     }
@@ -520,6 +569,7 @@ impl<'a, 'b, T> Mul<&'a Mat<T>> for View<'b, T> where T: Gemm + One + Zero {
 
 impl<'a, 'b, 'c, T> Mul<&'a MutView<'b, T>> for View<'c, T> where T: Gemm + One + Zero {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &MutView<T>) -> Mat<T> {
         self * rhs.as_view()
     }
@@ -529,6 +579,7 @@ impl<'a, 'b, T> Mul<&'a Trans<Mat<T>>> for View<'b, T> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<Mat<T>>) -> Mat<T> {
         self * Trans(rhs.0.as_view())
     }
@@ -538,6 +589,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Trans<MutView<'b, T>>> for View<'c, T> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: &Trans<MutView<T>>) -> Mat<T> {
         self * Trans(rhs.0.as_view())
     }
@@ -547,6 +599,7 @@ impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for View<'b, T> where
     T: Gemm + One + Zero,
 {
     type Output = Mat<T>;
+
     fn mul(self, rhs: Trans<View<T>>) -> Mat<T> {
         let lhs = self;
 
@@ -559,6 +612,7 @@ impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for View<'b, T> where
 
 impl<'a, 'b, T> Mul<View<'a, T>> for View<'b, T> where T: Gemm + One + Zero {
     type Output = Mat<T>;
+
     fn mul(self, rhs: View<T>) -> Mat<T> {
         let lhs = self;
 
@@ -572,6 +626,7 @@ impl<'a, 'b, T> Mul<View<'a, T>> for View<'b, T> where T: Gemm + One + Zero {
 // row * col (dot product)
 impl<'a, 'b, T> Mul<Col<'a, T>> for &'b RowVec<T> where T: Dot + Zero {
     type Output = T;
+
     fn mul(self, rhs: Col<T>) -> T {
         self.as_row() * rhs
     }
@@ -579,6 +634,7 @@ impl<'a, 'b, T> Mul<Col<'a, T>> for &'b RowVec<T> where T: Dot + Zero {
 
 impl<'a, 'b, T> Mul<&'a ColVec<T>> for &'b RowVec<T> where T: Dot + Zero {
     type Output = T;
+
     fn mul(self, rhs: &ColVec<T>) -> T {
         self.as_row() * rhs.as_col()
     }
@@ -586,6 +642,7 @@ impl<'a, 'b, T> Mul<&'a ColVec<T>> for &'b RowVec<T> where T: Dot + Zero {
 
 impl<'a, 'b, 'c, T> Mul<&'a MutCol<'b, T>> for &'c RowVec<T> where T: Dot + Zero {
     type Output = T;
+
     fn mul(self, rhs: &MutCol<T>) -> T {
         self.as_row() * rhs.as_col()
     }
@@ -593,6 +650,7 @@ impl<'a, 'b, 'c, T> Mul<&'a MutCol<'b, T>> for &'c RowVec<T> where T: Dot + Zero
 
 impl<'a, 'b, T> Mul<Col<'a, T>> for Row<'b, T> where T: Dot + Zero {
     type Output = T;
+
     fn mul(self, rhs: Col<T>) -> T {
         assert_eq!(self.len(), rhs.len());
 
@@ -616,6 +674,7 @@ impl<'a, 'b, T> Mul<Col<'a, T>> for Row<'b, T> where T: Dot + Zero {
 
 impl<'a, 'b, T> Mul<&'a ColVec<T>> for Row<'b, T> where T: Dot + Zero {
     type Output = T;
+
     fn mul(self, rhs: &ColVec<T>) -> T {
         self * rhs.as_col()
     }
@@ -623,6 +682,7 @@ impl<'a, 'b, T> Mul<&'a ColVec<T>> for Row<'b, T> where T: Dot + Zero {
 
 impl<'a, 'b, 'c, T> Mul<&'a MutCol<'b, T>> for Row<'c, T> where T: Dot + Zero {
     type Output = T;
+
     fn mul(self, rhs: &MutCol<T>) -> T {
         self * rhs.as_col()
     }
@@ -630,6 +690,7 @@ impl<'a, 'b, 'c, T> Mul<&'a MutCol<'b, T>> for Row<'c, T> where T: Dot + Zero {
 
 impl<'a, 'b, 'c, T> Mul<Col<'a, T>> for &'b MutRow<'c, T> where T: Dot + Zero {
     type Output = T;
+
     fn mul(self, rhs: Col<T>) -> T {
         self.as_row() * rhs
     }
@@ -637,6 +698,7 @@ impl<'a, 'b, 'c, T> Mul<Col<'a, T>> for &'b MutRow<'c, T> where T: Dot + Zero {
 
 impl<'a, 'b, 'c, T> Mul<&'a ColVec<T>> for &'b MutRow<'c, T> where T: Dot + Zero {
     type Output = T;
+
     fn mul(self, rhs: &ColVec<T>) -> T {
         self.as_row() * rhs.as_col()
     }
@@ -644,6 +706,7 @@ impl<'a, 'b, 'c, T> Mul<&'a ColVec<T>> for &'b MutRow<'c, T> where T: Dot + Zero
 
 impl<'a, 'b, 'c, 'd, T> Mul<&'a MutCol<'b, T>> for &'c MutRow<'d, T> where T: Dot + Zero {
     type Output = T;
+
     fn mul(self, rhs: &MutCol<T>) -> T {
         self.as_row() * rhs.as_col()
     }
@@ -652,6 +715,7 @@ impl<'a, 'b, 'c, 'd, T> Mul<&'a MutCol<'b, T>> for &'c MutRow<'d, T> where T: Do
 // row * mat (gemv)
 impl<'a, 'b, 'c, T> Mul<&'a Mat<T>> for &'b MutRow<'c, T> where T: Gemv + One + Zero {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &Mat<T>) -> RowVec<T> {
         self.as_row() * rhs.as_view()
     }
@@ -661,6 +725,7 @@ impl<'a, 'b, 'c, 'd, T> Mul<&'a MutView<'b, T>> for &'c MutRow<'d, T> where
     T: Gemv + One + Zero,
 {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &MutView<T>) -> RowVec<T> {
         self.as_row() * rhs.as_view()
     }
@@ -670,6 +735,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Trans<Mat<T>>> for &'b MutRow<'c, T> where
     T: Gemv + One + Zero,
 {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &Trans<Mat<T>>) -> RowVec<T> {
         self.as_row() * Trans(rhs.0.as_view())
     }
@@ -679,6 +745,7 @@ impl<'a, 'b, 'c, 'd, T> Mul<&'a Trans<MutView<'b, T>>> for &'c MutRow<'d, T> whe
     T: Gemv + One + Zero,
 {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &Trans<MutView<T>>) -> RowVec<T> {
         self.as_row() * Trans(rhs.0.as_view())
     }
@@ -688,6 +755,7 @@ impl<'a, 'b, 'c, T> Mul<Trans<View<'a, T>>> for &'b MutRow<'c, T> where
     T: Gemv + One + Zero,
 {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: Trans<View<T>>) -> RowVec<T> {
         self.as_row() * rhs
     }
@@ -695,6 +763,7 @@ impl<'a, 'b, 'c, T> Mul<Trans<View<'a, T>>> for &'b MutRow<'c, T> where
 
 impl<'a, 'b, 'c, T> Mul<View<'a, T>> for &'b MutRow<'c, T> where T: Gemv + One + Zero {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: View<T>) -> RowVec<T> {
         self.as_row() * rhs
     }
@@ -702,6 +771,7 @@ impl<'a, 'b, 'c, T> Mul<View<'a, T>> for &'b MutRow<'c, T> where T: Gemv + One +
 
 impl<'a, 'b, T> Mul<&'a Mat<T>> for Row<'b, T> where T: Gemv + One + Zero {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &Mat<T>) -> RowVec<T> {
         self * rhs.as_view()
     }
@@ -709,6 +779,7 @@ impl<'a, 'b, T> Mul<&'a Mat<T>> for Row<'b, T> where T: Gemv + One + Zero {
 
 impl<'a, 'b, 'c, T> Mul<&'a MutView<'b, T>> for Row<'c, T> where T: Gemv + One + Zero {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &MutView<T>) -> RowVec<T> {
         self * rhs.as_view()
     }
@@ -718,6 +789,7 @@ impl<'a, 'b, T> Mul<&'a Trans<Mat<T>>> for Row<'b, T> where
     T: Gemv + One + Zero,
 {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &Trans<Mat<T>>) -> RowVec<T> {
         self * Trans(rhs.0.as_view())
     }
@@ -727,6 +799,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Trans<MutView<'b, T>>> for Row<'c, T> where
     T: Gemv + One + Zero,
 {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &Trans<MutView<T>>) -> RowVec<T> {
         self * Trans(rhs.0.as_view())
     }
@@ -734,6 +807,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Trans<MutView<'b, T>>> for Row<'c, T> where
 
 impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for Row<'b, T> where T: Gemv + One + Zero {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: Trans<View<T>>) -> RowVec<T> {
         let lhs = self;
 
@@ -747,6 +821,7 @@ impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for Row<'b, T> where T: Gemv + One + Zer
 
 impl<'a, 'b, T> Mul<View<'a, T>> for Row<'b, T> where T: Gemv + One + Zero {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: View<T>) -> RowVec<T> {
         let lhs = self;
 
@@ -760,6 +835,7 @@ impl<'a, 'b, T> Mul<View<'a, T>> for Row<'b, T> where T: Gemv + One + Zero {
 
 impl<'a, 'b, T> Mul<&'a Mat<T>> for &'b RowVec<T> where T: Gemv + One + Zero {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &Mat<T>) -> RowVec<T> {
         self.as_row() * rhs.as_view()
     }
@@ -769,6 +845,7 @@ impl<'a, 'b, 'c, T> Mul<&'a MutView<'b, T>> for &'c RowVec<T> where
     T: Gemv + One + Zero,
 {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &MutView<T>) -> RowVec<T> {
         self.as_row() * rhs.as_view()
     }
@@ -778,6 +855,7 @@ impl<'a, 'b, T> Mul<&'a Trans<Mat<T>>> for &'b RowVec<T> where
     T: Gemv + One + Zero,
 {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &Trans<Mat<T>>) -> RowVec<T> {
         self.as_row() * Trans(rhs.0.as_view())
     }
@@ -787,6 +865,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Trans<MutView<'b, T>>> for &'c RowVec<T> where
     T: Gemv + One + Zero,
 {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: &Trans<MutView<T>>) -> RowVec<T> {
         self.as_row() * Trans(rhs.0.as_view())
     }
@@ -794,6 +873,7 @@ impl<'a, 'b, 'c, T> Mul<&'a Trans<MutView<'b, T>>> for &'c RowVec<T> where
 
 impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for &'b RowVec<T> where T: Gemv + One + Zero {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: Trans<View<T>>) -> RowVec<T> {
         self.as_row() * rhs
     }
@@ -801,6 +881,7 @@ impl<'a, 'b, T> Mul<Trans<View<'a, T>>> for &'b RowVec<T> where T: Gemv + One + 
 
 impl<'a, 'b, T> Mul<View<'a, T>> for &'b RowVec<T> where T: Gemv + One + Zero {
     type Output = RowVec<T>;
+
     fn mul(self, rhs: View<T>) -> RowVec<T> {
         self.as_row() * rhs
     }

--- a/src/raw/cols.rs
+++ b/src/raw/cols.rs
@@ -32,6 +32,7 @@ impl<'a, M> ::From<&'a M> for Cols<'a, M> where M: Matrix {
 
 impl<'a, T, M> Iterator for Cols<'a, M> where M: MatrixCol<T> {
     type Item = Col<'a, T>;
+
     fn next(&mut self) -> Option<Col<'a, T>> {
         if self.state == self.stop {
             None

--- a/src/raw/cols.rs
+++ b/src/raw/cols.rs
@@ -9,7 +9,7 @@ pub struct Cols<'a, M: 'a> {
 
 impl<'a, M> Copy for Cols<'a, M> {}
 
-impl<'a, T, M> DoubleEndedIterator for Cols<'a, M> where M: MatrixCol<T> {
+impl<'a, T, M> DoubleEndedIterator for Cols<'a, M> where M: MatrixCol + Matrix<Elem=T> {
     fn next_back(&mut self) -> Option<Col<'a, T>> {
         if self.state == self.stop {
             None
@@ -30,7 +30,7 @@ impl<'a, M> ::From<&'a M> for Cols<'a, M> where M: Matrix {
     }
 }
 
-impl<'a, T, M> Iterator for Cols<'a, M> where M: MatrixCol<T> {
+impl<'a, T, M> Iterator for Cols<'a, M> where M: MatrixCol + Matrix<Elem=T> {
     type Item = Col<'a, T>;
 
     fn next(&mut self) -> Option<Col<'a, T>> {

--- a/src/raw/rows.rs
+++ b/src/raw/rows.rs
@@ -9,7 +9,7 @@ pub struct Rows<'a, M: 'a> {
 
 impl<'a, M> Copy for Rows<'a, M> {}
 
-impl<'a, T, M> DoubleEndedIterator for Rows<'a, M> where M: MatrixRow<T> {
+impl<'a, T, M> DoubleEndedIterator for Rows<'a, M> where M: MatrixRow + Matrix<Elem=T> {
     fn next_back(&mut self) -> Option<Row<'a, T>> {
         if self.state == self.stop {
             None
@@ -30,7 +30,7 @@ impl<'a, M> ::From<&'a M> for Rows<'a, M> where M: Matrix {
     }
 }
 
-impl<'a, T, M> Iterator for Rows<'a, M> where M: MatrixRow<T> {
+impl<'a, T, M> Iterator for Rows<'a, M> where M: MatrixRow + Matrix<Elem=T> {
     type Item = Row<'a, T>;
 
     fn next(&mut self) -> Option<Row<'a, T>> {

--- a/src/raw/rows.rs
+++ b/src/raw/rows.rs
@@ -32,6 +32,7 @@ impl<'a, M> ::From<&'a M> for Rows<'a, M> where M: Matrix {
 
 impl<'a, T, M> Iterator for Rows<'a, M> where M: MatrixRow<T> {
     type Item = Row<'a, T>;
+
     fn next(&mut self) -> Option<Row<'a, T>> {
         if self.state == self.stop {
             None

--- a/src/raw/strided.rs
+++ b/src/raw/strided.rs
@@ -17,6 +17,7 @@ impl<'a, T> Copy for Items<'a, T> {}
 
 impl<'a, T> Iterator for Items<'a, T> {
     type Item = &'a T;
+
     fn next(&mut self) -> Option<&'a T> {
         if self.state == self.stop {
             None

--- a/src/raw/view.rs
+++ b/src/raw/view.rs
@@ -155,6 +155,7 @@ impl<'a, T> Copy for Items<'a, T> {}
 
 impl<'a, T> Iterator for Items<'a, T> {
     type Item = &'a T;
+
     fn next(&mut self) -> Option<&'a T> {
         if self.col == self.ncols {
             None

--- a/src/row.rs
+++ b/src/row.rs
@@ -2,6 +2,8 @@ use traits::{Matrix, Transpose};
 use {Col, MutCol, MutRow, Row};
 
 impl<'a, T> Matrix for MutRow<'a, T> {
+    type Elem = T;
+
     fn ncols(&self) -> uint {
         self.len()
     }
@@ -11,13 +13,17 @@ impl<'a, T> Matrix for MutRow<'a, T> {
     }
 }
 
-impl<'a, T> Transpose<MutCol<'a, T>> for MutRow<'a, T> {
+impl<'a, T> Transpose for MutRow<'a, T> {
+    type Output = MutCol<'a, T>;
+
     fn t(self) -> MutCol<'a, T> {
         MutCol(self.0)
     }
 }
 
 impl<'a, T> Matrix for Row<'a, T> {
+    type Elem = T;
+
     fn ncols(&self) -> uint {
         self.len()
     }
@@ -27,7 +33,9 @@ impl<'a, T> Matrix for Row<'a, T> {
     }
 }
 
-impl<'a, T> Transpose<Col<'a, T>> for Row<'a, T> {
+impl<'a, T> Transpose for Row<'a, T> {
+    type Output = Col<'a, T>;
+
     fn t(self) -> Col<'a, T> {
         Col(self.0)
     }

--- a/src/rows.rs
+++ b/src/rows.rs
@@ -11,6 +11,7 @@ impl<'a, T, M> DoubleEndedIterator for Rows<'a, M> where M: MatrixRow<T> {
 
 impl<'a, T, M> Iterator for Rows<'a, M> where M: MatrixRow<T> {
     type Item = Row<'a, T>;
+
     fn next(&mut self) -> Option<Row<'a, T>> {
         self.0.next()
     }
@@ -28,6 +29,7 @@ impl<'a, T, M> DoubleEndedIterator for MutRows<'a, M> where M: MatrixRowMut<T> {
 
 impl<'a, T, M> Iterator for MutRows<'a, M> where M: MatrixRowMut<T> {
     type Item = MutRow<'a, T>;
+
     fn next(&mut self) -> Option<MutRow<'a, T>> {
         unsafe { mem::transmute(self.0.next()) }
     }

--- a/src/rows.rs
+++ b/src/rows.rs
@@ -1,15 +1,15 @@
 use std::mem;
 
-use traits::{MatrixRow, MatrixRowMut};
+use traits::{Matrix, MatrixRow, MatrixRowMut};
 use {Row, Rows, MutRow, MutRows};
 
-impl<'a, T, M> DoubleEndedIterator for Rows<'a, M> where M: MatrixRow<T> {
+impl<'a, T, M> DoubleEndedIterator for Rows<'a, M> where M: MatrixRow + Matrix<Elem=T> {
     fn next_back(&mut self) -> Option<Row<'a, T>> {
         self.0.next_back()
     }
 }
 
-impl<'a, T, M> Iterator for Rows<'a, M> where M: MatrixRow<T> {
+impl<'a, T, M> Iterator for Rows<'a, M> where M: MatrixRow + Matrix<Elem=T> {
     type Item = Row<'a, T>;
 
     fn next(&mut self) -> Option<Row<'a, T>> {
@@ -21,13 +21,13 @@ impl<'a, T, M> Iterator for Rows<'a, M> where M: MatrixRow<T> {
     }
 }
 
-impl<'a, T, M> DoubleEndedIterator for MutRows<'a, M> where M: MatrixRowMut<T> {
+impl<'a, T, M> DoubleEndedIterator for MutRows<'a, M> where M: MatrixRowMut + Matrix<Elem=T> {
     fn next_back(&mut self) -> Option<MutRow<'a, T>> {
         unsafe { mem::transmute(self.0.next_back()) }
     }
 }
 
-impl<'a, T, M> Iterator for MutRows<'a, M> where M: MatrixRowMut<T> {
+impl<'a, T, M> Iterator for MutRows<'a, M> where M: MatrixRowMut + Matrix<Elem=T> {
     type Item = MutRow<'a, T>;
 
     fn next(&mut self) -> Option<MutRow<'a, T>> {

--- a/src/scaled.rs
+++ b/src/scaled.rs
@@ -8,6 +8,7 @@ impl<'a, T, M> Iterator for Scaled<T, Rows<'a, M>> where
     M: MatrixRow<T>,
 {
     type Item = Scaled<T, Row<'a, T>>;
+
     fn next(&mut self) -> Option<Scaled<T, Row<'a, T>>> {
         self.1.next().map(|r| Scaled(self.0.clone(), r))
     }
@@ -18,6 +19,7 @@ impl<'a, T, M> Iterator for Scaled<T, Cols<'a, M>> where
     M: MatrixCol<T>,
 {
     type Item = Scaled<T, Col<'a, T>>;
+
     fn next(&mut self) -> Option<Scaled<T, Col<'a, T>>> {
         self.1.next().map(|r| Scaled(self.0.clone(), r))
     }
@@ -40,6 +42,7 @@ impl<T, M> Matrix for Scaled<T, M> where M: Matrix {
 // col
 impl<'a, T> Mul<T> for Col<'a, T> {
     type Output = Scaled<T, Col<'a, T>>;
+
     fn mul(self, rhs: T) -> Scaled<T, Col<'a, T>> {
         Scaled(rhs, self)
     }
@@ -47,6 +50,7 @@ impl<'a, T> Mul<T> for Col<'a, T> {
 
 impl<'a, T> Mul<Col<'a, T>> for T {
     type Output = Scaled<T, Col<'a, T>>;
+
     fn mul(self, rhs: Col<'a, T>) -> Scaled<T, Col<'a, T>> {
         rhs * self
     }
@@ -54,6 +58,7 @@ impl<'a, T> Mul<Col<'a, T>> for T {
 
 impl<'a, T> Mul<T> for &'a ColVec<T> {
     type Output = Scaled<T, Col<'a, T>>;
+
     fn mul(self, rhs: T) -> Scaled<T, Col<'a, T>> {
         Scaled(rhs, self.as_col())
     }
@@ -61,6 +66,7 @@ impl<'a, T> Mul<T> for &'a ColVec<T> {
 
 impl<'a, T> Mul<&'a ColVec<T>> for T {
     type Output = Scaled<T, Col<'a, T>>;
+
     fn mul(self, rhs: &'a ColVec<T>) -> Scaled<T, Col<'a, T>> {
         rhs * self
     }
@@ -68,6 +74,7 @@ impl<'a, T> Mul<&'a ColVec<T>> for T {
 
 impl<'a, 'b, T> Mul<T> for &'a MutCol<'b, T> {
     type Output = Scaled<T, Col<'a, T>>;
+
     fn mul(self, rhs: T) -> Scaled<T, Col<'a, T>> {
         Scaled(rhs, self.as_col())
     }
@@ -75,6 +82,7 @@ impl<'a, 'b, T> Mul<T> for &'a MutCol<'b, T> {
 
 impl<'a, 'b, T> Mul<&'a MutCol<'b, T>> for T {
     type Output = Scaled<T, Col<'a, T>>;
+
     fn mul(self, rhs: &'a MutCol<'b, T>) -> Scaled<T, Col<'a, T>> {
         rhs * self
     }
@@ -83,6 +91,7 @@ impl<'a, 'b, T> Mul<&'a MutCol<'b, T>> for T {
 // mat
 impl<'a, T> Mul<T> for &'a Mat<T> {
     type Output = Scaled<T, View<'a, T>>;
+
     fn mul(self, rhs: T) -> Scaled<T, View<'a, T>> {
         Scaled(rhs, self.as_view())
     }
@@ -90,6 +99,7 @@ impl<'a, T> Mul<T> for &'a Mat<T> {
 
 impl<'a, T> Mul<&'a Mat<T>> for T {
     type Output = Scaled<T, View<'a, T>>;
+
     fn mul(self, rhs: &'a Mat<T>) -> Scaled<T, View<'a, T>> {
         rhs * self
     }
@@ -97,6 +107,7 @@ impl<'a, T> Mul<&'a Mat<T>> for T {
 
 impl<'a, 'b, T> Mul<T> for &'a MutView<'b, T> {
     type Output = Scaled<T, View<'a, T>>;
+
     fn mul(self, rhs: T) -> Scaled<T, View<'a, T>> {
         Scaled(rhs, self.as_view())
     }
@@ -104,6 +115,7 @@ impl<'a, 'b, T> Mul<T> for &'a MutView<'b, T> {
 
 impl<'a, 'b, T> Mul<&'a MutView<'b, T>> for T {
     type Output = Scaled<T, View<'a, T>>;
+
     fn mul(self, rhs: &'a MutView<'b, T>) -> Scaled<T, View<'a, T>> {
         rhs * self
     }
@@ -111,6 +123,7 @@ impl<'a, 'b, T> Mul<&'a MutView<'b, T>> for T {
 
 impl<'a, T> Mul<T> for &'a Trans<Mat<T>> {
     type Output = Scaled<T, Trans<View<'a, T>>>;
+
     fn mul(self, rhs: T) -> Scaled<T, Trans<View<'a, T>>> {
         Scaled(rhs, Trans(self.0.as_view()))
     }
@@ -118,6 +131,7 @@ impl<'a, T> Mul<T> for &'a Trans<Mat<T>> {
 
 impl<'a, T> Mul<&'a Trans<Mat<T>>> for T {
     type Output = Scaled<T, Trans<View<'a, T>>>;
+
     fn mul(self, rhs: &'a Trans<Mat<T>>) -> Scaled<T, Trans<View<'a, T>>> {
         rhs * self
     }
@@ -125,6 +139,7 @@ impl<'a, T> Mul<&'a Trans<Mat<T>>> for T {
 
 impl<'a, 'b, T> Mul<T> for &'a Trans<MutView<'b, T>> {
     type Output = Scaled<T, Trans<View<'a, T>>>;
+
     fn mul(self, rhs: T) -> Scaled<T, Trans<View<'a, T>>> {
         Scaled(rhs, Trans(self.0.as_view()))
     }
@@ -132,6 +147,7 @@ impl<'a, 'b, T> Mul<T> for &'a Trans<MutView<'b, T>> {
 
 impl<'a, 'b, T> Mul<&'a Trans<MutView<'b, T>>> for T {
     type Output = Scaled<T, Trans<View<'a, T>>>;
+
     fn mul(self, rhs: &'a Trans<MutView<'b, T>>) -> Scaled<T, Trans<View<'a, T>>> {
         rhs * self
     }
@@ -139,6 +155,7 @@ impl<'a, 'b, T> Mul<&'a Trans<MutView<'b, T>>> for T {
 
 impl<'a, T> Mul<T> for Trans<View<'a, T>> {
     type Output = Scaled<T, Trans<View<'a, T>>>;
+
     fn mul(self, rhs: T) -> Scaled<T, Trans<View<'a, T>>> {
         Scaled(rhs, self)
     }
@@ -146,12 +163,14 @@ impl<'a, T> Mul<T> for Trans<View<'a, T>> {
 
 impl<'a, T> Mul<Trans<View<'a, T>>> for T {
     type Output = Scaled<T, Trans<View<'a, T>>>;
+
     fn mul(self, rhs: Trans<View<'a, T>>) -> Scaled<T, Trans<View<'a, T>>> {
         rhs * self
     }
 }
 impl<'a, T> Mul<T> for View<'a, T> {
     type Output = Scaled<T, View<'a, T>>;
+
     fn mul(self, rhs: T) -> Scaled<T, View<'a, T>> {
         Scaled(rhs, self)
     }
@@ -159,6 +178,7 @@ impl<'a, T> Mul<T> for View<'a, T> {
 
 impl<'a, T> Mul<View<'a, T>> for T {
     type Output = Scaled<T, View<'a, T>>;
+
     fn mul(self, rhs: View<'a, T>) -> Scaled<T, View<'a, T>> {
         rhs * self
     }
@@ -167,6 +187,7 @@ impl<'a, T> Mul<View<'a, T>> for T {
 // row
 impl<'a, T> Mul<T> for Row<'a, T> {
     type Output = Scaled<T, Row<'a, T>>;
+
     fn mul(self, rhs: T) -> Scaled<T, Row<'a, T>> {
         Scaled(rhs, self)
     }
@@ -174,6 +195,7 @@ impl<'a, T> Mul<T> for Row<'a, T> {
 
 impl<'a, T> Mul<Row<'a, T>> for T {
     type Output = Scaled<T, Row<'a, T>>;
+
     fn mul(self, rhs: Row<'a, T>) -> Scaled<T, Row<'a, T>> {
         rhs * self
     }
@@ -181,6 +203,7 @@ impl<'a, T> Mul<Row<'a, T>> for T {
 
 impl<'a, T> Mul<T> for &'a RowVec<T> {
     type Output = Scaled<T, Row<'a, T>>;
+
     fn mul(self, rhs: T) -> Scaled<T, Row<'a, T>> {
         Scaled(rhs, self.as_row())
     }
@@ -188,6 +211,7 @@ impl<'a, T> Mul<T> for &'a RowVec<T> {
 
 impl<'a, T> Mul<&'a RowVec<T>> for T {
     type Output = Scaled<T, Row<'a, T>>;
+
     fn mul(self, rhs: &'a RowVec<T>) -> Scaled<T, Row<'a, T>> {
         rhs * self
     }
@@ -195,6 +219,7 @@ impl<'a, T> Mul<&'a RowVec<T>> for T {
 
 impl<'a, 'b, T> Mul<T> for &'a MutRow<'b, T> {
     type Output = Scaled<T, Row<'a, T>>;
+
     fn mul(self, rhs: T) -> Scaled<T, Row<'a, T>> {
         Scaled(rhs, self.as_row())
     }
@@ -202,6 +227,7 @@ impl<'a, 'b, T> Mul<T> for &'a MutRow<'b, T> {
 
 impl<'a, 'b, T> Mul<&'a MutRow<'b, T>> for T {
     type Output = Scaled<T, Row<'a, T>>;
+
     fn mul(self, rhs: &'a MutRow<'b, T>) -> Scaled<T, Row<'a, T>> {
         rhs * self
     }
@@ -210,6 +236,7 @@ impl<'a, 'b, T> Mul<&'a MutRow<'b, T>> for T {
 // scaled
 impl<T, M> Mul<T> for Scaled<T, M> where T: Mul<Output=T> {
     type Output = Scaled<T, M>;
+
     fn mul(self, rhs: T) -> Scaled<T, M> {
         Scaled(self.0 * rhs, self.1)
     }
@@ -217,6 +244,7 @@ impl<T, M> Mul<T> for Scaled<T, M> where T: Mul<Output=T> {
 
 impl<T, M> Mul<Scaled<T, M>> for T where T: Mul<Output=T> {
     type Output = Scaled<T, M>;
+
     fn mul(self, rhs: Scaled<T, M>) -> Scaled<T, M> {
         rhs * self
     }

--- a/src/scaled.rs
+++ b/src/scaled.rs
@@ -5,7 +5,7 @@ use traits::{Matrix, MatrixCol, MatrixRow};
 
 impl<'a, T, M> Iterator for Scaled<T, Rows<'a, M>> where
     T: Clone,
-    M: MatrixRow<T>,
+    M: MatrixRow + Matrix<Elem=T>,
 {
     type Item = Scaled<T, Row<'a, T>>;
 
@@ -16,7 +16,7 @@ impl<'a, T, M> Iterator for Scaled<T, Rows<'a, M>> where
 
 impl<'a, T, M> Iterator for Scaled<T, Cols<'a, M>> where
     T: Clone,
-    M: MatrixCol<T>,
+    M: MatrixCol + Matrix<Elem=T>,
 {
     type Item = Scaled<T, Col<'a, T>>;
 
@@ -25,7 +25,9 @@ impl<'a, T, M> Iterator for Scaled<T, Cols<'a, M>> where
     }
 }
 
-impl<T, M> Matrix for Scaled<T, M> where M: Matrix {
+impl<T, M> Matrix for Scaled<T, M> where M: Matrix<Elem=T> {
+    type Elem = T;
+
     fn ncols(&self) -> uint {
         self.1.ncols()
     }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -7,7 +7,9 @@ use {
 };
 use traits::{Matrix, Slice, SliceMut};
 
-impl<'a, T> ::Slice<'a, uint, strided::Slice<'a, T>> for [T] {
+impl<'a, T> ::Slice<'a, uint> for [T] {
+    type Slice = strided::Slice<'a, T>;
+
     fn slice(&'a self, start: uint, end: uint) -> Result<strided::Slice<'a, T>> {
         let raw::Slice { data, len } = self.repr();
 
@@ -37,7 +39,9 @@ macro_rules! from_to {
     }
 }
 
-impl<'a, T> Slice<'a, uint, Col<'a, T>> for ColVec<T> {
+impl<'a, T> Slice<'a, uint> for ColVec<T> {
+    type Slice = Col<'a, T>;
+
     fn slice(&'a self, start: uint, end: uint) -> Result<Col<'a, T>> {
         ::Slice::slice(&*self.0, start, end).map(Col)
     }
@@ -45,7 +49,9 @@ impl<'a, T> Slice<'a, uint, Col<'a, T>> for ColVec<T> {
     from_to!(Col<'a, T>);
 }
 
-impl<'a, 'b, T> Slice<'a, uint, Col<'a, T>> for Col<'b, T> {
+impl<'a, 'b, T> Slice<'a, uint> for Col<'b, T> {
+    type Slice = Col<'a, T>;
+
     fn slice(&'a self, start: uint, end: uint) -> Result<Col<'a, T>> {
         self.0.slice(start, end).map(Col)
     }
@@ -53,7 +59,9 @@ impl<'a, 'b, T> Slice<'a, uint, Col<'a, T>> for Col<'b, T> {
     from_to!(Col<'a, T>);
 }
 
-impl<'a, 'b, T> Slice<'a, uint, Diag<'a, T>> for Diag<'b, T> {
+impl<'a, 'b, T> Slice<'a, uint> for Diag<'b, T> {
+    type Slice = Diag<'a, T>;
+
     fn slice(&'a self, start: uint, end: uint) -> Result<Diag<'a, T>> {
         self.0.slice(start, end).map(Diag)
     }
@@ -61,7 +69,9 @@ impl<'a, 'b, T> Slice<'a, uint, Diag<'a, T>> for Diag<'b, T> {
     from_to!(Diag<'a, T>);
 }
 
-impl<'a, T> Slice<'a, (uint, uint), View<'a, T>> for Mat<T> {
+impl<'a, T> Slice<'a, (uint, uint)> for Mat<T> {
+    type Slice = View<'a, T>;
+
     fn slice(
         &'a self,
         (start_row, start_col): (uint, uint),
@@ -97,7 +107,9 @@ impl<'a, T> Slice<'a, (uint, uint), View<'a, T>> for Mat<T> {
     }
 }
 
-impl<'a, 'b, T> Slice<'a, uint, Col<'a, T>> for MutCol<'b, T> {
+impl<'a, 'b, T> Slice<'a, uint> for MutCol<'b, T> {
+    type Slice = Col<'a, T>;
+
     fn slice(&'a self, start: uint, end: uint) -> Result<Col<'a, T>> {
         self.0.slice(start, end).map(Col)
     }
@@ -105,7 +117,9 @@ impl<'a, 'b, T> Slice<'a, uint, Col<'a, T>> for MutCol<'b, T> {
     from_to!(Col<'a, T>);
 }
 
-impl<'a, 'b, T> Slice<'a, uint, Diag<'a, T>> for MutDiag<'b, T> {
+impl<'a, 'b, T> Slice<'a, uint> for MutDiag<'b, T> {
+    type Slice = Diag<'a, T>;
+
     fn slice(&'a self, start: uint, end: uint) -> Result<Diag<'a, T>> {
         self.0.slice(start, end).map(Diag)
     }
@@ -113,7 +127,9 @@ impl<'a, 'b, T> Slice<'a, uint, Diag<'a, T>> for MutDiag<'b, T> {
     from_to!(Diag<'a, T>);
 }
 
-impl<'a, 'b, T> Slice<'a, uint, Row<'a, T>> for MutRow<'b, T> {
+impl<'a, 'b, T> Slice<'a, uint> for MutRow<'b, T> {
+    type Slice = Row<'a, T>;
+
     fn slice(&'a self, start: uint, end: uint) -> Result<Row<'a, T>> {
         self.0.slice(start, end).map(Row)
     }
@@ -121,7 +137,9 @@ impl<'a, 'b, T> Slice<'a, uint, Row<'a, T>> for MutRow<'b, T> {
     from_to!(Row<'a, T>);
 }
 
-impl<'a, T> Slice<'a, uint, Row<'a, T>> for RowVec<T> {
+impl<'a, T> Slice<'a, uint> for RowVec<T> {
+    type Slice = Row<'a, T>;
+
     fn slice(&'a self, start: uint, end: uint) -> Result<Row<'a, T>> {
         ::Slice::slice(&*self.0, start, end).map(Row)
     }
@@ -129,7 +147,9 @@ impl<'a, T> Slice<'a, uint, Row<'a, T>> for RowVec<T> {
     from_to!(Row<'a, T>);
 }
 
-impl<'a, 'b, T> Slice<'a, uint, Row<'a, T>> for Row<'b, T> {
+impl<'a, 'b, T> Slice<'a, uint> for Row<'b, T> {
+    type Slice = Row<'a, T>;
+
     fn slice(&'a self, start: uint, end: uint) -> Result<Row<'a, T>> {
         self.0.slice(start, end).map(Row)
     }
@@ -149,7 +169,9 @@ macro_rules! from_to2 {
     }
 }
 
-impl<'a, 'b, T> Slice<'a, (uint, uint), View<'a, T>> for MutView<'b, T> {
+impl<'a, 'b, T> Slice<'a, (uint, uint)> for MutView<'b, T> {
+    type Slice = View<'a, T>;
+
     fn slice(&'a self, start: (uint, uint), end: (uint, uint)) -> Result<View<'a, T>> {
         unsafe { mem::transmute(self.0.slice(start, end)) }
     }
@@ -157,7 +179,9 @@ impl<'a, 'b, T> Slice<'a, (uint, uint), View<'a, T>> for MutView<'b, T> {
     from_to2!(View<'a, T>);
 }
 
-impl<'a, 'b, T> Slice<'a, (uint, uint), View<'a, T>> for View<'b, T> {
+impl<'a, 'b, T> Slice<'a, (uint, uint)> for View<'b, T> {
+    type Slice = View<'a, T>;
+
     fn slice(&'a self, start: (uint, uint), end: (uint, uint)) -> Result<View<'a, T>> {
         unsafe { mem::transmute(self.0.slice(start, end)) }
     }
@@ -179,7 +203,9 @@ macro_rules! from_to_mut {
     }
 }
 
-impl<'a, T> SliceMut<'a, uint, MutCol<'a, T>> for ColVec<T> {
+impl<'a, T> SliceMut<'a, uint> for ColVec<T> {
+    type Slice = MutCol<'a, T>;
+
     fn slice_mut(&'a mut self, start: uint, end: uint) -> Result<MutCol<'a, T>> {
         unsafe { mem::transmute(::Slice::slice(&*self.0, start, end)) }
     }
@@ -187,7 +213,9 @@ impl<'a, T> SliceMut<'a, uint, MutCol<'a, T>> for ColVec<T> {
     from_to_mut!(MutCol<'a, T>);
 }
 
-impl<'a, T> SliceMut<'a, (uint, uint), MutView<'a, T>> for Mat<T> {
+impl<'a, T> SliceMut<'a, (uint, uint)> for Mat<T> {
+    type Slice = MutView<'a, T>;
+
     fn slice_mut(&'a mut self, start: (uint, uint), end: (uint, uint)) -> Result<MutView<'a, T>> {
         unsafe { mem::transmute(self.slice(start, end)) }
     }
@@ -203,7 +231,9 @@ impl<'a, T> SliceMut<'a, (uint, uint), MutView<'a, T>> for Mat<T> {
     }
 }
 
-impl<'a, 'b, T> SliceMut<'a, uint, MutCol<'a, T>> for MutCol<'b, T> {
+impl<'a, 'b, T> SliceMut<'a, uint> for MutCol<'b, T> {
+    type Slice = MutCol<'a, T>;
+
     fn slice_mut(&'a mut self, start: uint, end: uint) -> Result<MutCol<'a, T>> {
         self.0.slice_mut(start, end).map(MutCol)
     }
@@ -211,7 +241,9 @@ impl<'a, 'b, T> SliceMut<'a, uint, MutCol<'a, T>> for MutCol<'b, T> {
     from_to_mut!(MutCol<'a, T>);
 }
 
-impl<'a, 'b, T> SliceMut<'a, uint, MutDiag<'a, T>> for MutDiag<'b, T> {
+impl<'a, 'b, T> SliceMut<'a, uint> for MutDiag<'b, T> {
+    type Slice = MutDiag<'a, T>;
+
     fn slice_mut(&'a mut self, start: uint, end: uint) -> Result<MutDiag<'a, T>> {
         self.0.slice_mut(start, end).map(MutDiag)
     }
@@ -219,7 +251,9 @@ impl<'a, 'b, T> SliceMut<'a, uint, MutDiag<'a, T>> for MutDiag<'b, T> {
     from_to_mut!(MutDiag<'a, T>);
 }
 
-impl<'a, 'b, T> SliceMut<'a, uint, MutRow<'a, T>> for MutRow<'b, T> {
+impl<'a, 'b, T> SliceMut<'a, uint> for MutRow<'b, T> {
+    type Slice = MutRow<'a, T>;
+
     fn slice_mut(&'a mut self, start: uint, end: uint) -> Result<MutRow<'a, T>> {
         self.0.slice_mut(start, end).map(MutRow)
     }
@@ -227,7 +261,9 @@ impl<'a, 'b, T> SliceMut<'a, uint, MutRow<'a, T>> for MutRow<'b, T> {
     from_to_mut!(MutRow<'a, T>);
 }
 
-impl<'a, 'b, T> SliceMut<'a, (uint, uint), MutView<'a, T>> for MutView<'b, T> {
+impl<'a, 'b, T> SliceMut<'a, (uint, uint)> for MutView<'b, T> {
+    type Slice = MutView<'a, T>;
+
     fn slice_mut(&'a mut self, start: (uint, uint), end: (uint, uint)) -> Result<MutView<'a, T>> {
         unsafe { mem::transmute(self.0.slice(start, end)) }
     }
@@ -243,7 +279,9 @@ impl<'a, 'b, T> SliceMut<'a, (uint, uint), MutView<'a, T>> for MutView<'b, T> {
     }
 }
 
-impl<'a, T> SliceMut<'a, uint, MutRow<'a, T>> for RowVec<T> {
+impl<'a, T> SliceMut<'a, uint> for RowVec<T> {
+    type Slice = MutRow<'a, T>;
+
     fn slice_mut(&'a mut self, start: uint, end: uint) -> Result<MutRow<'a, T>> {
         unsafe { mem::transmute(::Slice::slice(&*self.0, start, end)) }
     }

--- a/src/strided/mod.rs
+++ b/src/strided/mod.rs
@@ -109,6 +109,7 @@ impl<'a, T> DoubleEndedIterator for Items<'a, T> {
 
 impl<'a, T> Iterator for Items<'a, T> {
     type Item = &'a T;
+
     fn next(&mut self) -> Option<&'a T> {
         unsafe { mem::transmute(self.0.next()) }
     }
@@ -129,6 +130,7 @@ impl<'a, T> DoubleEndedIterator for MutItems<'a, T> {
 
 impl<'a, T> Iterator for MutItems<'a, T> {
     type Item = &'a mut T;
+
     fn next(&mut self) -> Option<&'a mut T> {
         unsafe { mem::transmute(self.0.next()) }
     }

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -9,6 +9,7 @@ macro_rules! sub0 {
     ($lhs:ty, $rhs:ty) => {
         impl<T> Sub<$rhs> for $lhs where T: Axpy + Neg<Output=T> + One {
             type Output = $lhs;
+
             fn sub(mut self, rhs: $rhs) -> $lhs {
                 self.sub_assign(rhs);
                 self
@@ -21,6 +22,7 @@ macro_rules! sub1 {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, T> Sub<$rhs> for $lhs where T: Axpy + Neg<Output=T> + One {
             type Output = $lhs;
+
             fn sub(mut self, rhs: $rhs) -> $lhs {
                 self.sub_assign(rhs);
                 self
@@ -33,6 +35,7 @@ macro_rules! sub1c {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, T> Sub<$rhs> for $lhs where T: Axpy + Neg<Output=T> + One + Clone {
             type Output = $lhs;
+
             fn sub(mut self, rhs: $rhs) -> $lhs {
                 self.sub_assign(rhs);
                 self
@@ -45,6 +48,7 @@ macro_rules! sub2 {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, 'b, T> Sub<$rhs> for $lhs where T: Axpy + Neg<Output=T> + One {
             type Output = $lhs;
+
             fn sub(mut self, rhs: $rhs) -> $lhs {
                 self.sub_assign(rhs);
                 self
@@ -57,6 +61,7 @@ macro_rules! sub2c {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, 'b, T> Sub<$rhs> for $lhs where T: Axpy + Clone + Neg<Output=T> + One {
             type Output = $lhs;
+
             fn sub(mut self, rhs: $rhs) -> $lhs {
                 self.sub_assign(rhs);
                 self
@@ -69,6 +74,7 @@ macro_rules! sub3 {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, 'b, 'c, T> Sub<$rhs> for $lhs where T: Axpy + Neg<Output=T> + One {
             type Output = $lhs;
+
             fn sub(mut self, rhs: $rhs) -> $lhs {
                 self.sub_assign(rhs);
                 self

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,7 +13,7 @@ pub trait AddAssign<R> {
 }
 
 /// Bounds-checked immutable indexing
-pub trait At<I> for Sized? {
+pub trait At<I> {
     type Output;
 
     /// Returns an immutable reference to the element at the given index
@@ -25,7 +25,7 @@ pub trait At<I> for Sized? {
 }
 
 /// Bounds-checked mutable indexing
-pub trait AtMut<I> for Sized? {
+pub trait AtMut<I> {
     type Output;
 
     /// Returns a mutable reference to the element at the given index

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,43 +13,51 @@ pub trait AddAssign<R> {
 }
 
 /// Bounds-checked immutable indexing
-// FIXME (AI) `T` should be an associated type
-pub trait At<I, T> for Sized? {
+pub trait At<I> for Sized? {
+    type Output;
+
     /// Returns an immutable reference to the element at the given index
     ///
     /// # Errors
     ///
     /// - `OutOfBounds` if the index is out of bounds
-    fn at(&self, index: I) -> ::std::result::Result<&T, OutOfBounds>;
+    fn at(&self, index: I) -> ::std::result::Result<&Self::Output, OutOfBounds>;
 }
 
 /// Bounds-checked mutable indexing
-// FIXME (AI) `T` should be an associated type
-pub trait AtMut<I, T> for Sized? {
+pub trait AtMut<I> for Sized? {
+    type Output;
+
     /// Returns a mutable reference to the element at the given index
     ///
     /// # Errors
     ///
     /// - `OutOfBounds` if the index is out of bounds
-    fn at_mut(&mut self, index: I) -> ::std::result::Result<&mut T, OutOfBounds>;
+    fn at_mut(&mut self, index: I) -> ::std::result::Result<&mut Self::Output, OutOfBounds>;
 }
 
 /// Immutable iteration over a collection
-// FIXME (AI) `'a`, `T`, `I` should be associated items
-pub trait Iter<'a, T, I: Iterator> {
+// FIXME (AI) `'a` should be associated items
+pub trait Iter<'a> {
+    type Iter: Iterator;
+
     /// Returns an iterator that yields immutable references to the elements of the collection
-    fn iter(&'a self) -> I;
+    fn iter(&'a self) -> Self::Iter;
 }
 
 /// Mutable iteration over a collection
-// FIXME (AI) `'a`, `T`, `I` should be associated items
-pub trait IterMut<'a, T, I: Iterator> {
+// FIXME (AI) `'a`, should be associated items
+pub trait IterMut<'a> {
+    type Iter: Iterator;
+
     /// Returns an iterator that yields mutable references to the elements of the collection
-    fn iter_mut(&'a mut self) -> I;
+    fn iter_mut(&'a mut self) -> Self::Iter;
 }
 
 /// The basic idea of a matrix: A rectangular array arranged in rows and columns
 pub trait Matrix: Sized {
+    type Elem;
+
     /// Returns the number of columns the matrix has
     fn ncols(&self) -> uint {
         self.size().1
@@ -67,14 +75,13 @@ pub trait Matrix: Sized {
 }
 
 /// Immutable view on a column
-// FIXME (AI) `T` should be an associated type
-pub trait MatrixCol<T>: Matrix {
+pub trait MatrixCol: Matrix {
     /// Returns an immutable view into the column at the given index
     ///
     /// # Errors
     ///
     /// - `NoSuchColumn` if the index is out of bounds
-    fn col(&self, col: uint) -> Result<Col<T>> {
+    fn col(&self, col: uint) -> Result<Col<Self::Elem>> {
         if col < self.ncols() {
             Ok(unsafe { self.unsafe_col(col) })
         } else {
@@ -83,18 +90,17 @@ pub trait MatrixCol<T>: Matrix {
     }
 
     /// Returns a view into the column at the given index without performing bounds checking
-    unsafe fn unsafe_col(&self, col: uint) -> Col<T>;
+    unsafe fn unsafe_col(&self, col: uint) -> Col<Self::Elem>;
 }
 
 /// Mutable access to a column
-// FIXME (AI) `T` should be an associated type
-pub trait MatrixColMut<T>: MatrixCol<T> {
+pub trait MatrixColMut: MatrixCol {
     /// Returns a mutable view into the column at the given index
     ///
     /// # Errors
     ///
     /// - `NoSuchColumn` if the index is out of bounds
-    fn col_mut(&mut self, col: uint) -> Result<MutCol<T>> {
+    fn col_mut(&mut self, col: uint) -> Result<MutCol<Self::Elem>> {
         if col < self.ncols() {
             Ok(unsafe { self.unsafe_col_mut(col) })
         } else {
@@ -104,7 +110,7 @@ pub trait MatrixColMut<T>: MatrixCol<T> {
 
     /// Returns a mutable view into the column at the given index without performing bounds
     /// checking
-    unsafe fn unsafe_col_mut(&mut self, col: uint) -> MutCol<T>;
+    unsafe fn unsafe_col_mut(&mut self, col: uint) -> MutCol<Self::Elem>;
 }
 
 /// Immutable column-by-column iteration
@@ -116,25 +122,23 @@ pub trait MatrixCols: Matrix {
 }
 
 /// Immutable view on a diagonal
-// FIXME (AI) `T` should be an associated type
-pub trait MatrixDiag<T> {
+pub trait MatrixDiag: Matrix {
     /// Returns a view into the diagonal at the given index
     ///
     /// # Errors
     ///
     /// - `NoSuchDiagonal` if the index is out of bounds
-    fn diag(&self, diag: int) -> Result<Diag<T>>;
+    fn diag(&self, diag: int) -> Result<Diag<Self::Elem>>;
 }
 
 /// Mutable access to a diagonal
-// FIXME (AI) `T` should be an associated type
-pub trait MatrixDiagMut<T> {
+pub trait MatrixDiagMut: Matrix {
     /// Returns a mutable view into the diagonal at the given index
     ///
     /// # Errors
     ///
     /// - `NoSuchDiagonal` if the index is out of bounds
-    fn diag_mut(&mut self, diag: int) -> ::Result<MutDiag<T>>;
+    fn diag_mut(&mut self, diag: int) -> ::Result<MutDiag<Self::Elem>>;
 }
 
 /// Mutable column-by-column iteration
@@ -154,14 +158,13 @@ pub trait MatrixMutRows: Matrix {
 }
 
 /// Immutable view into a row
-// FIXME (AI) `T` should be an associated type
-pub trait MatrixRow<T>: Matrix {
+pub trait MatrixRow: Matrix {
     /// Returns an immutable view into the row at the given index
     ///
     /// # Errors
     ///
     /// - `NoSuchRow` if the index is out of bounds
-    fn row(&self, row: uint) -> Result<Row<T>> {
+    fn row(&self, row: uint) -> Result<Row<Self::Elem>> {
         if row < self.nrows() {
             Ok(unsafe { self.unsafe_row(row) })
         } else {
@@ -171,7 +174,7 @@ pub trait MatrixRow<T>: Matrix {
 
     /// Returns an immutable view into the row at the given index without performing bounds
     /// checking
-    unsafe fn unsafe_row(&self, row: uint) -> Row<T>;
+    unsafe fn unsafe_row(&self, row: uint) -> Row<Self::Elem>;
 }
 
 /// Immutable row-by-row iteration
@@ -183,14 +186,13 @@ pub trait MatrixRows: Matrix {
 }
 
 /// Mutable access to a row
-// FIXME (AI) `T` should be an associated type
-pub trait MatrixRowMut<T>: MatrixRow<T> {
+pub trait MatrixRowMut: MatrixRow {
     /// Returns a mutable view into the row at the given index
     ///
     /// # Errors
     ///
     /// - `NoSuchRow` if the index is out of bounds
-    fn row_mut(&mut self, row: uint) -> Result<MutRow<T>> {
+    fn row_mut(&mut self, row: uint) -> Result<MutRow<Self::Elem>> {
         if row < self.nrows() {
             Ok(unsafe { self.unsafe_row_mut(row) })
         } else {
@@ -199,7 +201,7 @@ pub trait MatrixRowMut<T>: MatrixRow<T> {
     }
 
     /// Returns a mutable view into the row at the given index without performing bounds checking
-    unsafe fn unsafe_row_mut(&mut self, row: uint) -> MutRow<T>;
+    unsafe fn unsafe_row_mut(&mut self, row: uint) -> MutRow<Self::Elem>;
 }
 
 /// The `*=` operator
@@ -215,25 +217,29 @@ pub trait MulAssign<R> {
 ///
 /// *Note* Sadly this doesn't have operator sugar. You won't be able to use the slicing operator
 /// `[]` with this library until Rust gets HKT.
-// FIXME (AI) `'a`, `R` should be associated items
-pub trait Slice<'a, I, S> {
+// FIXME (AI) `'a` should be associated items
+pub trait Slice<'a, I> {
+    type Slice;
+
     /// Returns an immutable view into a fraction of the collection that spans `start` : `end`
-    fn slice(&'a self, start: I, end: I) -> ::Result<S>;
+    fn slice(&'a self, start: I, end: I) -> ::Result<Self::Slice>;
     /// Convenience method for `slice(start, end_of_collection)`
-    fn slice_from(&'a self, start: I) -> ::Result<S>;
+    fn slice_from(&'a self, start: I) -> ::Result<Self::Slice>;
     /// Convenience method for `slice(start_of_collection, end)`
-    fn slice_to(&'a self, end: I) -> ::Result<S>;
+    fn slice_to(&'a self, end: I) -> ::Result<Self::Slice>;
 }
 
 /// Mutable version of the `Slice` trait
-// FIXME (AI) `'a`, `R` should be associated items
-pub trait SliceMut<'a, I, S> {
+// FIXME (AI) `'a`, should be associated items
+pub trait SliceMut<'a, I> {
+    type Slice;
+
     /// Returns a mutable view into a fraction of the collection that spans `start` : `end`
-    fn slice_mut(&'a mut self, start: I, end: I) -> ::Result<S>;
+    fn slice_mut(&'a mut self, start: I, end: I) -> ::Result<Self::Slice>;
     /// Convenience method for `slice_mut(start, end_of_collection)`
-    fn slice_from_mut(&'a mut self, start: I) -> ::Result<S>;
+    fn slice_from_mut(&'a mut self, start: I) -> ::Result<Self::Slice>;
     /// Convenience method for `slice_mut(start_of_collection, end)`
-    fn slice_to_mut(&'a mut self, end: I) -> ::Result<S>;
+    fn slice_to_mut(&'a mut self, end: I) -> ::Result<Self::Slice>;
 }
 
 /// The `-=` operator
@@ -253,8 +259,9 @@ pub trait ToOwned<T> {
 }
 
 /// The transpose operator
-// FIXME (AI) `T` should be an associated type
-pub trait Transpose<T> {
+pub trait Transpose {
+    type Output;
+
     /// Returns the transpose of the input
-    fn t(self) -> T;
+    fn t(self) -> Self::Output;
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -42,19 +42,21 @@ impl<'a, T> ::From<(*const T, uint, uint, uint)> for View<'a, T> {
     }
 }
 
-impl<'a, 'b, T> IterMut<'b, &'b mut T, MutItems<'b, T>> for MutView<'a, T> {
+impl<'a, 'b, T> IterMut<'b> for MutView<'a, T> {
+    type Iter = MutItems<'b, T>;
+
     fn iter_mut(&'b mut self) -> MutItems<'b, T> {
         MutItems(self.0.iter())
     }
 }
 
-impl<'a, T> MatrixColMut<T> for MutView<'a, T> {
+impl<'a, T> MatrixColMut for MutView<'a, T> {
     unsafe fn unsafe_col_mut(&mut self, col: uint) -> MutCol<T> {
         mem::transmute(self.0.unsafe_col(col))
     }
 }
 
-impl<'a, T> MatrixDiagMut<T> for MutView<'a, T> {
+impl<'a, T> MatrixDiagMut for MutView<'a, T> {
     fn diag_mut(&mut self, diag: int) -> Result<MutDiag<T>> {
         unsafe { mem::transmute(self.0.diag(diag)) }
     }
@@ -64,7 +66,7 @@ impl<'a, T> MatrixMutCols for MutView<'a, T> {}
 
 impl<'a, T> MatrixMutRows for MutView<'a, T> {}
 
-impl<'a, T> MatrixRowMut<T> for MutView<'a, T> {
+impl<'a, T> MatrixRowMut for MutView<'a, T> {
     unsafe fn unsafe_row_mut(&mut self, row: uint) -> MutRow<T> {
         mem::transmute(self.0.unsafe_row(row))
     }
@@ -73,13 +75,17 @@ impl<'a, T> MatrixRowMut<T> for MutView<'a, T> {
 macro_rules! impls {
     ($($ty:ty),+) => {
         $(
-            impl<'a, 'b, T> Iter<'b, &'b T, Items<'b, T>> for $ty {
+            impl<'a, 'b, T> Iter<'b> for $ty {
+                type Iter = Items<'b, T>;
+
                 fn iter(&'b self) -> Items<'b, T> {
                     Items(self.0.iter())
                 }
             }
 
             impl<'a, T> Matrix for $ty {
+                type Elem = T;
+
                 fn ncols(&self) -> uint {
                     self.0.ncols()
                 }
@@ -89,7 +95,7 @@ macro_rules! impls {
                 }
             }
 
-            impl<'a, T> MatrixCol<T> for $ty {
+            impl<'a, T> MatrixCol for $ty {
                 unsafe fn unsafe_col(&self, col: uint) -> Col<T> {
                     self.0.unsafe_col(col)
                 }
@@ -97,13 +103,13 @@ macro_rules! impls {
 
             impl<'a, T> MatrixCols for $ty {}
 
-            impl<'a, T> MatrixDiag<T> for $ty {
+            impl<'a, T> MatrixDiag for $ty {
                 fn diag(&self, diag: int) -> Result<Diag<T>> {
                     self.0.diag(diag)
                 }
             }
 
-            impl<'a, T> MatrixRow<T> for $ty {
+            impl<'a, T> MatrixRow for $ty {
                 unsafe fn unsafe_row(&self, row: uint) -> Row<T> {
                     self.0.unsafe_row(row)
                 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -8,6 +8,7 @@ use traits::{
 
 impl<'a, T> Iterator for Items<'a, T> {
     type Item = &'a T;
+
     fn next(&mut self) -> Option<&'a T> {
         self.0.next()
     }
@@ -19,6 +20,7 @@ impl<'a, T> Iterator for Items<'a, T> {
 
 impl<'a, T> Iterator for MutItems<'a, T> {
     type Item = &'a mut T;
+
     fn next(&mut self) -> Option<&'a mut T> {
         unsafe { mem::transmute(self.0.next()) }
     }

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -47,7 +47,7 @@ macro_rules! enforce {
 
 macro_rules! test {
     ($e:expr) => {
-        (|| Ok::<_, ::linalg::Error>(TestResult::from_bool($e)))().unwrap()
+        (|&:| Ok::<_, ::linalg::Error>(TestResult::from_bool($e)))().unwrap()
     }
 }
 


### PR DESCRIPTION
This doesn't break any use of the concrete API (all tests continue to pass)

However if you were using the traits for generic programming, this is a [breaking-change].